### PR TITLE
Add showFsn flag in parse-search-params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1344,6 +1344,7 @@ Search parameters:
 * `fuzzy` - whether to use fuzziness for search (default, `false`)
 * `fallbackFuzzy` - whether to retry using a fuzziness factor if initial search returns no results (default, `false`)
 * `removeDuplicates` - whether to remove consecutive results with the same conceptId and text (default, `false`)
+* `showFsn` - whether to show the fully specified name in the results (default, `false`)
 
 For autocompletion, in a typical type-ahead user interface control, you might use `fallbackFuzzy=1` (or
 `fallbackFuzzy=true`) and `removeDuplicates=1` (or `removeDuplicates=true`).

--- a/cmd/com/eldrix/hermes/cmd/server.clj
+++ b/cmd/com/eldrix/hermes/cmd/server.clj
@@ -233,7 +233,7 @@
          (assoc ctx :result {:subsumedBy (hermes/subsumed-by? svc concept-id subsumer-id)})))}))
 
 (defn parse-search-params
-  [{:keys [s maxHits isA refset constraint ecl fuzzy fallbackFuzzy inactiveConcepts inactiveDescriptions removeDuplicates]}]
+  [{:keys [s maxHits isA refset constraint ecl fuzzy fallbackFuzzy inactiveConcepts inactiveDescriptions removeDuplicates showFsn]}]
   (cond-> {}
     s (assoc :s s)
     constraint (assoc :constraint constraint)
@@ -247,7 +247,8 @@
     fallbackFuzzy (assoc :fallback-fuzzy (if (parse-flag fallbackFuzzy) 2 0))
     inactiveConcepts (assoc :inactive-concepts? (parse-flag inactiveConcepts))
     inactiveDescriptions (assoc :inactive-descriptions? (parse-flag inactiveDescriptions))
-    removeDuplicates (assoc :remove-duplicates? (parse-flag removeDuplicates))))
+    removeDuplicates (assoc :remove-duplicates? (parse-flag removeDuplicates))
+    showFsn (assoc :show-fsn? (parse-flag showFsn))))
 
 (def get-search
   (intc/interceptor


### PR DESCRIPTION
Summary:
- Add a flag to the search API to show the fully-specified name of a concept

Background:
- We are exploring using a terminology server for our use-case. Being able to show the FSN in the search result would be helpful