### PR TITLE
Add OWL reasoning and refine SCG compositional grammar

### DIFF
--- a/.github/workflows/test-live-ar.yml
+++ b/.github/workflows/test-live-ar.yml
@@ -48,4 +48,4 @@ jobs:
         run: clojure -M:run --db snomed.db status
 
       - name: Run tests
-        run: clojure -M:test -e :uk
+        run: clojure -M:test -e :uk -e :slow

--- a/.github/workflows/test-live-uk.yml
+++ b/.github/workflows/test-live-uk.yml
@@ -56,4 +56,4 @@ jobs:
         run: clojure -M:run --db snomed.db status
 
       - name: Clojure tests
-        run: clojure -M:test
+        run: clojure -M:test -e :slow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         run: clojure -P -M:test
 
       - name: Compilation check
-        run:  clojure -M:dev:check
+        run:  clojure -M:dev:owl:check
 
       - name: Clojure tests
         run: clojure -M:test -e :live

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ hermes.iml
 .DS_Store
 .lsp/
 mlds-password.txt
+*.iml

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Hermes provides a set of terminology tools built around SNOMED CT including:
 
 * a fast terminology service with full-text search functionality; ideal for driving autocompletion in user interfaces
 * an inference engine in order to analyse SNOMED CT expressions and concepts and derive meaning
+* optional OWL reasoning for post-coordinated expression classification, subsumption and normal forms
 * cross-mapping to and from other code systems including ICD-10, Read codes and OPCS
 * support for SNOMED CT compositional grammar (cg) and expression constraint language (ECL) v2.2.
 * a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for use with AI assistants and LLM-based tools
@@ -78,9 +79,11 @@ supports search and autocompletion using the $expand operation.
     - [Expanding SNOMED ECL (Expression Constraint Language)](#expanding-ecl-without-search)
     - [Crossmap to and from SNOMED CT - e.g. ICD-10](#crossmap-to-and-from-snomed-ct)
     - [Map a concept into a reference set](#map-a-concept-into-a-reference-set)
+    - [OWL reasoning endpoints](#owl-reasoning-endpoints)
   - [C. Embed into another application as a JVM library](#c-embed-into-another-application)
-  - [D. Development notes](#d-development)
-  - [E. Backwards compatibility and versioning](#e-backwards-compatibility-and-versioning)
+  - [D. OWL reasoning](#d-owl-reasoning)
+  - [E. Development notes](#e-development)
+  - [F. Backwards compatibility and versioning](#f-backwards-compatibility-and-versioning)
 
 # Quickstart
 
@@ -1622,6 +1625,60 @@ into subsets of terms as defined by a reference set for analytics.
 
 You could limit users to only entering the terms in a subset, but much better to allow clinicians to regard highly-specific granular terms and be able to map to less granular terms on demand.
 
+##### OWL reasoning endpoints
+
+These endpoints are available when the server is started with the `--owl` flag.
+See [OWL reasoning](#d-owl-reasoning) for setup instructions.
+
+###### Get server status
+
+```shell
+http '127.0.0.1:8080/v1/snomed/status'
+```
+
+Returns status information including the current reasoning status (`active`, `inactive`, or `unavailable`).
+
+###### Expression subsumption
+
+```shell
+http '127.0.0.1:8080/v1/snomed/subsumes?a=73211009&b=73211009|46..|:363698007=84301002'
+```
+
+Tests whether expression `a` subsumes expression `b`. Parameters:
+
+| Parameter | Required | Description                                                              |
+|-----------|----------|--------------------------------------------------------------------------|
+| `a`       | yes      | SCG expression                                                           |
+| `b`       | yes      | SCG expression                                                           |
+| `mode`    | no       | `structural` (default) or `owl`. OWL mode requires `--owl` at startup.   |
+
+Returns `{"outcome": "equivalent"}`, `{"outcome": "subsumes"}`, `{"outcome": "subsumed-by"}`, or `{"outcome": "not-subsumed"}`.
+
+###### Classify expression
+
+```shell
+http '127.0.0.1:8080/v1/snomed/classify?expression=73211009|46..|:363698007=84301002'
+```
+
+Classifies a post-coordinated expression using OWL reasoning. Returns equivalent concepts, direct super-concepts, and proximal primitive supertypes.
+
+| Parameter    | Required | Description    |
+|--------------|----------|----------------|
+| `expression` | yes      | SCG expression |
+
+###### Necessary Normal Form
+
+```shell
+http '127.0.0.1:8080/v1/snomed/necessary-normal-form?expression=73211009|46..|:363698007=84301002'
+```
+
+Computes the Necessary Normal Form (NNF) of a post-coordinated expression. The NNF
+has proximal primitive supertypes as focus concepts plus all necessary relationships.
+
+| Parameter    | Required | Description    |
+|--------------|----------|----------------|
+| `expression` | yes      | SCG expression |
+
 ### C. Embed into another application
 
 You can use git coordinates in a deps.edn file, or use maven:
@@ -1655,11 +1712,85 @@ You may need to add Clojars as a repository in your build tool. Here for maven:
 </repositories>
 ```
 
-### D. Development
+### D. OWL reasoning
 
-See [/doc/development](/doc/development.md) on how to develop, test, lint, deploy and release `hermes`. 
+Hermes provides optional OWL reasoning for post-coordinated expressions using the
+[OWL API](https://github.com/owlcs/owlapi) and the [ELK reasoner](https://github.com/liveontologies/elk-reasoner).
 
-### E. Backwards compatibility and versioning
+OWL reasoning enables:
+
+* **Classification** of post-coordinated expressions — determining equivalent concepts,
+  direct super-concepts, and proximal primitive supertypes
+* **Subsumption testing** using OWL semantics — more accurate than structural subsumption
+  for complex expressions
+* **Necessary Normal Form (NNF)** computation — a canonical representation with proximal
+  primitive supertypes as focus concepts and all necessary relationships
+
+OWL reasoning is entirely optional. When the OWL libraries are not on the classpath,
+or the `--owl` flag is not used, hermes continues to work as before with structural
+subsumption.
+
+#### Setup
+
+The OWL API and ELK reasoner are not included in the default classpath. To enable
+OWL reasoning, add the `:owl` alias when running from source:
+
+```shell
+clj -M:run:owl --db snomed.db import ~/Downloads/snomed-2021/
+clj -M:run:owl --db snomed.db --owl serve
+```
+
+When importing, the `--owl` flag controls whether OWL axiom reference set files are
+included. By default, they are excluded. When serving, the `--owl` flag activates
+the reasoner at startup, making classification, OWL subsumption, and NNF endpoints
+available.
+
+If you are using a pre-built jar that includes the OWL dependencies:
+
+```shell
+java -jar hermes.jar --db snomed.db --owl import ~/Downloads/snomed-2021/
+java -jar hermes.jar --db snomed.db --owl serve
+```
+
+The `--owl` flag is also supported by the `install` and `mcp` commands.
+
+#### Library usage
+
+When embedding hermes in another application, add the OWL dependencies to your
+project:
+
+```clojure
+net.sourceforge.owlapi/owlapi-apibinding {:mvn/version "5.5.1"
+                                           :exclusions  [net.sourceforge.owlapi/owlapi-rio
+                                                         net.sourceforge.owlapi/owlapi-oboformat
+                                                         net.sourceforge.owlapi/owlapi-tools]}
+io.github.liveontologies/elk-owlapi      {:mvn/version "0.6.0"}
+```
+
+Then use the reasoning functions from `com.eldrix.hermes.core`:
+
+```clojure
+(require '[com.eldrix.hermes.core :as hermes])
+
+(def svc (hermes/open "snomed.db"))
+(hermes/activate-reasoner svc)            ;; eagerly initialize the reasoner
+(hermes/reasoning-status svc)             ;; => :active, :inactive, or :unavailable
+
+;; Classify a post-coordinated expression
+(hermes/classify-expression svc "73211009:363698007=84301002")
+
+;; Test subsumption (structural or OWL)
+(hermes/subsumes svc "73211009" "73211009:363698007=84301002" :mode :owl)
+
+;; Compute Necessary Normal Form
+(hermes/necessary-normal-form svc "73211009:363698007=84301002")
+```
+
+### E. Development
+
+See [/doc/development](/doc/development.md) on how to develop, test, lint, deploy and release `hermes`.
+
+### F. Backwards compatibility and versioning
 
 `Hermes` uses versions of form `major.minor.commit`
 

--- a/cmd/com/eldrix/hermes/cmd/cli.clj
+++ b/cmd/com/eldrix/hermes/cmd/cli.clj
@@ -63,6 +63,7 @@
                      :parse-fn keyword :validate [#{:json :edn} "Format must be 'json' or 'edn'"]]
    :dist            [nil "--dist DST" "Distribution(s) e.g. uk.nhs/sct-clinical"
                      :multi true :default [] :update-fn conj :default-desc ""]
+   :owl             [nil "--owl" "Enable OWL reasoning support"]
    :verbose         ["-v" "--verbose"]
    :progress        [nil "--progress" "Turn on progress reporting"]
    :help            ["-h" "--help"]})
@@ -136,15 +137,15 @@
     :opts [(option :help)]}
    {:cmd  "import" :usage "import [paths]"
     :desc "Import SNOMED distribution files from the path(s) specified"
-    :opts [(option :db db-mandatory) (option :help)]}
+    :opts [(option :db db-mandatory) (option :owl) (option :help)]}
    {:cmd  "available" :desc "List available distributions, or releases for 'install'"
     :opts #(make-distribution-options {:extra-opts [[nil "--username USERNAME" "Username for MLDS"]
                                                    [nil "--password PASSWORD_FILE" "Path to a file containing password for MLDS"]]} %)}
    {:cmd  "download" :usage "download [dists]" :deprecated true :warning "Use 'install' instead"
     :desc "Download and install specified distributions"
-    :opts #(make-distribution-options {:db? true} %)}
+    :opts #(make-distribution-options {:db? true :extra-opts [(option :owl)]} %)}
    {:cmd  "install" :desc "Download and install specified distribution(s)"
-    :opts #(make-distribution-options {:db? true} %)}
+    :opts #(make-distribution-options {:db? true :extra-opts [(option :owl)]} %)}
    {:cmd  "index" :desc "Build search indices"
     :opts [(option :db db-mandatory) (option :help)]}
    {:cmd  "compact" :desc "Compact database"
@@ -158,9 +159,9 @@
    {:cmd  "serve" :desc "Start a terminology server"
     :opts [(option :db db-mandatory) (option :port) (option :bind-address)
            (option :allowed-origins) (option :allowed-origin) (option :locale)
-           (option :help)]}
+           (option :owl) (option :help)]}
    {:cmd  "mcp" :desc "Start an MCP (Model Context Protocol) server"
-    :opts [(option :db db-mandatory) (option :locale) (option :help)]}])
+    :opts [(option :db db-mandatory) (option :locale) (option :owl) (option :help)]}])
 
 (def commands
   "Return information about the command specified."
@@ -201,14 +202,17 @@
         (update-in [:options :allowed-origin] #(apply conj % (str/split (:allowed-origins options) #","))))))
 
 (defn opts-for-commands
-  "Given a collection of command-line arguments, return sorted options."
-  [args]
-  (->> (filter all-commands args)
-       (map commands)
-       (map :opts)
-       (mapcat #(if (fn? %) (% args) %))
-       distinct
-       (sort-by second)))
+  "Given a collection of command-line arguments, return sorted options.
+  An optional set of option specs to exclude can be provided."
+  ([args] (opts-for-commands args #{}))
+  ([args exclude]
+   (->> (filter all-commands args)
+        (map commands)
+        (map :opts)
+        (mapcat #(if (fn? %) (% args) %))
+        (remove exclude)
+        distinct
+        (sort-by second))))
 
 (defn parse-cli
   "Parse command-line arguments and return a map containing:
@@ -218,18 +222,22 @@
   - :warnings  - a sequence of warnings, if any
   - :errors    - a sequence of errors, if any
 
-  Commands are returned in order given on the command-line."
-  [args]
-  (let [cmds (filterv all-commands args)                    ;; return commands in order given on command-line
-        opts (or (seq (opts-for-commands args)) [(option :help)])] ;; determine options for command(s)
-    (-> args
-        expand-legacy-parameters
-        (cli/parse-opts opts)
-        (update :arguments #(remove (set cmds) %))
-        (assoc :cmds cmds)
-        parse-allowed-origins
-        parse-legacy-distributions
-        warn-if-deprecated)))
+  Commands are returned in order given on the command-line.
+  An optional config map can be provided with:
+  - :exclude-opts - a set of option keywords to exclude."
+  ([args] (parse-cli args {}))
+  ([args {:keys [exclude-opts]}]
+   (let [excluded (set (keep all-options exclude-opts))
+         cmds (filterv all-commands args)
+         opts (or (seq (opts-for-commands args excluded)) [(option :help)])]
+     (-> args
+         expand-legacy-parameters
+         (cli/parse-opts opts)
+         (update :arguments #(remove (set cmds) %))
+         (assoc :cmds cmds)
+         parse-allowed-origins
+         parse-legacy-distributions
+         warn-if-deprecated))))
 
 (comment
   (def args ["--db wibble.db" "serve" "flibble"])

--- a/cmd/com/eldrix/hermes/cmd/core.clj
+++ b/cmd/com/eldrix/hermes/cmd/core.clj
@@ -18,6 +18,7 @@
    [com.eldrix.hermes.cmd.server :as server]
    [com.eldrix.hermes.core :as hermes]
    [com.eldrix.hermes.download :as download]
+   [com.eldrix.hermes.impl.reasoner :as reasoner]
    [com.eldrix.hermes.importer :as importer]
    [expound.alpha :as expound])
   (:import (clojure.lang ExceptionInfo)
@@ -44,10 +45,10 @@
      (uncaughtException [_ thread ex]
        (log/error ex "Uncaught exception on" (.getName thread))))))
 
-(defn import-from [{:keys [db]} args]
+(defn import-from [{:keys [db owl]} args]
   (set-default-uncaught-exception-handler)
   (let [dirs (if (zero? (count args)) ["."] args)]
-    (hermes/import-snomed db dirs)))
+    (hermes/import-snomed db dirs :exclude (when-not owl importer/default-exclude))))
 
 (defn list-from [_ args]
   (let [dirs (if (zero? (count args)) ["."] args)
@@ -99,12 +100,13 @@
       :json (json/pprint st)
       (clojure.pprint/pprint st))))
 
-(defn mcp [{:keys [db locale]} _]
+(defn mcp [{:keys [db locale owl]} _]
   (with-open [svc (hermes/open db {:default-locale locale})]
     (log-module-dependency-problems svc)
+    (when owl (hermes/activate-reasoner svc))
     (mcp/start! svc)))
 
-(defn serve [{:keys [db _port _bind-address allowed-origin locale] :as params} _]
+(defn serve [{:keys [db _port _bind-address allowed-origin locale owl] :as params} _]
   (let [svc (hermes/open db {:default-locale locale})
         params' (cond (= ["*"] allowed-origin) (assoc params :allowed-origins (constantly true))
                       (seq allowed-origin) (assoc params :allowed-origins allowed-origin)
@@ -113,6 +115,7 @@
                         (select-keys ["os.name" "os.arch" "os.version" "java.vm.name" "java.vm.version"])
                         (update-keys keyword)))
     (log-module-dependency-problems svc)
+    (when owl (hermes/activate-reasoner svc))
     (log/info "starting terminology server " (dissoc params' :allowed-origin))
     (server/start! svc params')))
 
@@ -161,7 +164,8 @@
     (exit 1 "ERROR: not implemented ")))
 
 (defn -main [& args]
-  (let [{:keys [cmds options arguments summary errors warnings]} (cli/parse-cli args)]
+  (let [{:keys [cmds options arguments summary errors warnings]}
+        (cli/parse-cli args {:exclude-opts (when-not @reasoner/owl-loaded? #{:owl})})]
     (doseq [warning warnings] (log/warn warning))
     (cond
       ;; asking for help with a specific command?

--- a/cmd/com/eldrix/hermes/cmd/server.clj
+++ b/cmd/com/eldrix/hermes/cmd/server.clj
@@ -310,7 +310,7 @@
            (and (= :owl mode') (not= :active (hermes/reasoning-status svc)))
            (assoc ctx :response {:status 422 :body {:error "OWL reasoning unavailable"}})
            :else
-           (assoc ctx :result {:outcome (name (hermes/expression-subsumes? svc a b :mode mode'))}))))}))
+           (assoc ctx :result {:outcome (name (hermes/subsumes svc a b :mode mode'))}))))}))
 
 (def classify-expression
   "OWL classification of a post-coordinated expression.

--- a/cmd/com/eldrix/hermes/cmd/server.clj
+++ b/cmd/com/eldrix/hermes/cmd/server.clj
@@ -284,7 +284,59 @@
      (fn [{svc ::svc :as ctx}]
        (assoc ctx :result (hermes/mrcm-domains svc)))}))
 
-(def routes
+(def get-status
+  (intc/interceptor
+    {:name ::get-status
+     :enter
+     (fn [{::keys [svc] :as ctx}]
+       (assoc ctx :result (assoc (hermes/status* svc {})
+                                 :reasoning (hermes/reasoning-status svc))))}))
+
+(def expression-subsumes
+  "Expression-level subsumption testing, aligned with FHIR CodeSystem/$subsumes.
+  Parameters: a, b (SCG expressions), mode ('owl' or 'structural', default structural).
+  Returns 422 if mode=owl and reasoning is unavailable."
+  (intc/interceptor
+    {:name ::expression-subsumes
+     :enter
+     (fn [{::keys [svc] :as ctx}]
+       (let [{:keys [a b mode]} (get-in ctx [:request :params])
+             mode' (if (= "owl" mode) :owl :structural)]
+         (cond
+           (str/blank? a)
+           (assoc ctx :response {:status 400 :body {:error "missing parameter: a"}})
+           (str/blank? b)
+           (assoc ctx :response {:status 400 :body {:error "missing parameter: b"}})
+           (and (= :owl mode') (not= :active (hermes/reasoning-status svc)))
+           (assoc ctx :response {:status 422 :body {:error "OWL reasoning unavailable"}})
+           :else
+           (assoc ctx :result {:outcome (name (hermes/expression-subsumes? svc a b :mode mode'))}))))}))
+
+(def classify-expression
+  "OWL classification of a post-coordinated expression.
+  Parameters: expression (SCG string)."
+  (intc/interceptor
+    {:name ::classify-expression
+     :enter
+     (fn [{::keys [svc] :as ctx}]
+       (let [expression (get-in ctx [:request :params :expression])]
+         (if (str/blank? expression)
+           (assoc ctx :response {:status 400 :body {:error "missing parameter: expression"}})
+           (assoc ctx :result (hermes/classify-expression svc expression)))))}))
+
+(def get-necessary-normal-form
+  "Compute the Necessary Normal Form (NNF) of a post-coordinated expression.
+  Parameters: expression (SCG string)."
+  (intc/interceptor
+    {:name ::get-necessary-normal-form
+     :enter
+     (fn [{::keys [svc] :as ctx}]
+       (let [expression (get-in ctx [:request :params :expression])]
+         (if (str/blank? expression)
+           (assoc ctx :response {:status 400 :body {:error "missing parameter: expression"}})
+           (assoc ctx :result (hermes/necessary-normal-form svc expression)))))}))
+
+(def ^:private base-routes
   #{["/v1/snomed/concepts/:concept-id" :get get-concept :constraints {:concept-id #"[0-9]+"}]
     ["/v1/snomed/concepts/:concept-id/descriptions" :get get-concept-descriptions :constraints {:concept-id #"[0-9]+"}]
     ["/v1/snomed/concepts/:concept-id/properties" :get get-concept-properties :constraints {:concept-id #"[0-9]+"}]
@@ -297,7 +349,20 @@
     ["/v1/snomed/crossmap/:refset-id/:code" :get get-map-from :constraints {:refset-id #"[0-9]+"}]
     ["/v1/snomed/search" :get get-search]
     ["/v1/snomed/expand" :get get-expand]
-    ["/v1/snomed/mrcm-domains" :get get-mrcm-domains]})
+    ["/v1/snomed/mrcm-domains" :get get-mrcm-domains]
+    ["/v1/snomed/status" :get get-status]
+    ["/v1/snomed/subsumes" :get expression-subsumes]})
+
+(def ^:private owl-routes
+  #{["/v1/snomed/classify" :get classify-expression]
+    ["/v1/snomed/necessary-normal-form" :get get-necessary-normal-form]})
+
+(defn routes
+  "Return the set of routes, conditionally including OWL reasoning endpoints."
+  [svc]
+  (cond-> base-routes
+    (= :active (hermes/reasoning-status svc))
+    (into owl-routes)))
 
 
 (defn create-connector
@@ -324,7 +389,7 @@
          service-error-handler
          content-neg-intc
          entity-render])
-      (conn/with-routes routes)
+      (conn/with-routes (routes svc))
       (jetty/create-connector {:join? join?})))
 
 (defn start! [svc config]

--- a/cmd/logback.xml
+++ b/cmd/logback.xml
@@ -13,6 +13,7 @@
     </root>
 
     <logger name="com.eldrix" level="info"/>
+    <logger name="org.semanticweb.elk.reasoner.completeness" level="error"/>
     <logger name="org.eclipse.jetty.server.Server" level="info"/>
 
 </configuration>

--- a/deps.edn
+++ b/deps.edn
@@ -64,7 +64,12 @@
                  ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
                  criterium/criterium            {:mvn/version "0.4.6"}
                  io.pedestal/pedestal.jetty     {:mvn/version "0.8.1"}
-                 io.pedestal/pedestal.service   {:mvn/version "0.8.1"}}
+                 io.pedestal/pedestal.service   {:mvn/version "0.8.1"}
+                 net.sourceforge.owlapi/owlapi-apibinding {:mvn/version "5.5.1"
+                                                                        :exclusions  [net.sourceforge.owlapi/owlapi-rio
+                                                                                      net.sourceforge.owlapi/owlapi-oboformat
+                                                                                      net.sourceforge.owlapi/owlapi-tools]}
+                 io.github.liveontologies/elk-owlapi      {:mvn/version "0.6.0"}}
    :main-opts   ["-m" "cognitect.test-runner"]
    :exec-fn     cognitect.test-runner.api/test}
 
@@ -94,6 +99,13 @@
    :main-opts   ["-m" "cognitect.test-runner" "-r" ".*bench$"]
    :exec-fn     cognitect.test-runner.api/test
    :exec-args   {:patterns [".*-bench$"]}}
+
+  :owl
+  {:extra-deps {net.sourceforge.owlapi/owlapi-apibinding {:mvn/version "5.5.1"
+                                                           :exclusions  [net.sourceforge.owlapi/owlapi-rio
+                                                                         net.sourceforge.owlapi/owlapi-oboformat
+                                                                         net.sourceforge.owlapi/owlapi-tools]}
+                io.github.liveontologies/elk-owlapi      {:mvn/version "0.6.0"}}}
 
   :outdated
   {:extra-deps {com.github.liquidz/antq {:mvn/version "2.11.1276"}}

--- a/src/com/eldrix/hermes/core.clj
+++ b/src/com/eldrix/hermes/core.clj
@@ -583,71 +583,107 @@
       :else
       :unavailable)))
 
+(defn ^:private ->ctu
+  "Coerce a concept identifier, SCG string, or parsed CTU expression to CTU."
+  [x]
+  (cond
+    (int? x)    (scg/str->ctu (str x))
+    (string? x) (scg/str->ctu x)
+    :else       x))
+
+(defn ^:private subsumes-concept-ids
+  "Fast subsumption for two concept identifiers using the IS-A hierarchy."
+  [store a b]
+  (cond
+    (= a b)                                    :equivalent
+    (contains? (store/all-parents store b) a)   :subsumes
+    (contains? (store/all-parents store a) b)   :subsumed-by
+    :else                                       :not-subsumed))
+
+(defn ^:private subsumes-ctu
+  "Structural subsumption between two CTU expressions."
+  [store ctu-a ctu-b]
+  (let [cf-a (scg/ctu->cf+normalize store ctu-a)
+        cf-b (scg/ctu->cf+normalize store ctu-b)
+        a-subsumes-b (scg/cf-subsumes? store cf-a cf-b)
+        b-subsumes-a (scg/cf-subsumes? store cf-b cf-a)]
+    (cond
+      (and a-subsumes-b b-subsumes-a) :equivalent
+      a-subsumes-b                    :subsumes
+      b-subsumes-a                    :subsumed-by
+      :else                           :not-subsumed)))
+
+(s/def ::expression (s/or :concept-id :info.snomed.Concept/id :string string? :ctu :ctu/expression))
 (s/def ::mode #{:structural :owl})
 
-(s/fdef expression-subsumes?
+(s/fdef subsumes
   :args (s/cat :svc ::svc
-               :a (s/or :string string? :ctu :ctu/expression)
-               :b (s/or :string string? :ctu :ctu/expression)
+               :a ::expression
+               :b ::expression
                :opts (s/keys* :opt-un [::mode]))
   :ret #{:equivalent :subsumes :subsumed-by :not-subsumed})
 
-(defn expression-subsumes?
-  "Does expression A subsume expression B?
-  Accepts SCG strings or parsed CTU expressions.
-  Uses structural subsumption by default. When :mode is :owl and a reasoner
-  is available, uses OWL reasoning; otherwise falls back to structural.
+(defn subsumes
+  "Test subsumption between two expressions, aligned with FHIR $subsumes.
+  Accepts concept identifiers, SCG strings, or parsed CTU expressions.
+  Uses structural subsumption by default. When :mode is :owl, uses OWL
+  reasoning; throws if the reasoner is unavailable.
 
   Returns :equivalent, :subsumes, :subsumed-by, or :not-subsumed."
-  [svc a b & {:keys [mode] :or {mode :structural}}]
-  (let [st (.-store ^Svc svc)
-        ctu-a (if (string? a) (scg/str->ctu a) a)
-        ctu-b (if (string? b) (scg/str->ctu b) b)]
-    (scg/validate st ctu-a)
-    (scg/validate st ctu-b)
-    (if-let [reasoner (and (= :owl mode) @(:reasoner svc))]
-      (reasoner/subsumes? reasoner (scg/ctu->cf ctu-a) (scg/ctu->cf ctu-b))
-      (let [cf-a (scg/ctu->cf+normalize st ctu-a)
-            cf-b (scg/ctu->cf+normalize st ctu-b)
-            a-subsumes-b (scg/cf-subsumes? st cf-a cf-b)
-            b-subsumes-a (scg/cf-subsumes? st cf-b cf-a)]
-        (cond
-          (and a-subsumes-b b-subsumes-a) :equivalent
-          a-subsumes-b                    :subsumes
-          b-subsumes-a                    :subsumed-by
-          :else                           :not-subsumed)))))
+  [{st :store reasoner :reasoner} a b & {:keys [mode] :or {mode :structural}}]
+  (cond
+    (and (int? a) (int? b) (not= :owl mode))
+    (subsumes-concept-ids st a b)
+
+    (= :owl mode)
+    (if-let [r @reasoner]
+      (let [ctu-a (->ctu a), ctu-b (->ctu b)]
+        (scg/validate st ctu-a)
+        (scg/validate st ctu-b)
+        (reasoner/subsumes? r (scg/ctu->cf ctu-a) (scg/ctu->cf ctu-b)))
+      (throw (ex-info "OWL reasoning unavailable" {:mode mode})))
+
+    :else
+    (let [ctu-a (->ctu a), ctu-b (->ctu b)]
+      (scg/validate st ctu-a)
+      (scg/validate st ctu-b)
+      (subsumes-ctu st ctu-a ctu-b))))
 
 (s/fdef classify-expression
-  :args (s/cat :svc ::svc :expression (s/or :string string? :ctu :ctu/expression))
-  :ret (s/nilable map?))
+  :args (s/cat :svc ::svc :expression ::expression
+               :opts (s/keys*))
+  :ret map?)
 
 (defn classify-expression
   "Classify a post-coordinated expression using OWL reasoning.
-  Accepts an SCG string or parsed CTU expression.
+  Accepts a concept identifier, SCG string, or parsed CTU expression.
   Returns a map with :equivalent-concepts, :direct-super-concepts,
-  and :proximal-primitive-supertypes, or nil if reasoning is unavailable."
-  [svc expression]
-  (when-let [reasoner @(:reasoner svc)]
-    (let [st (.-store ^Svc svc)
-          ctu (if (string? expression) (scg/str->ctu expression) expression)]
+  and :proximal-primitive-supertypes.
+  Throws if reasoning is unavailable."
+  [{st :store reasoner :reasoner} expression & {:as _opts}]
+  (if-let [r @reasoner]
+    (let [ctu (->ctu expression)]
       (scg/validate st ctu)
-      (reasoner/classify reasoner (scg/ctu->cf ctu)))))
+      (reasoner/classify r (scg/ctu->cf ctu)))
+    (throw (ex-info "OWL reasoning unavailable" {}))))
 
 (s/fdef necessary-normal-form
-  :args (s/cat :svc ::svc :expression (s/or :string string? :ctu :ctu/expression))
-  :ret (s/nilable :cf/expression))
+  :args (s/cat :svc ::svc :expression ::expression
+               :opts (s/keys*))
+  :ret :cf/expression)
 
 (defn necessary-normal-form
   "Compute the Necessary Normal Form of an expression using OWL reasoning.
-  Accepts an SCG string or parsed CTU expression.
+  Accepts a concept identifier, SCG string, or parsed CTU expression.
   Returns a CF expression with proximal primitive supertypes as focus
-  concepts plus all necessary relationships, or nil if unavailable."
-  [svc expression]
-  (when-let [reasoner @(:reasoner svc)]
-    (let [st (.-store ^Svc svc)
-          ctu (if (string? expression) (scg/str->ctu expression) expression)]
+  concepts plus all necessary relationships.
+  Throws if reasoning is unavailable."
+  [{st :store reasoner :reasoner} expression & {:as _opts}]
+  (if-let [r @reasoner]
+    (let [ctu (->ctu expression)]
       (scg/validate st ctu)
-      (reasoner/necessary-normal-form reasoner (scg/ctu->cf ctu)))))
+      (reasoner/necessary-normal-form r (scg/ctu->cf ctu)))
+    (throw (ex-info "OWL reasoning unavailable" {}))))
 
 (defn ^:private make-search-params
   [^Svc svc {:keys [s query constraint accept-language language-refset-ids] :as params}]

--- a/src/com/eldrix/hermes/core.clj
+++ b/src/com/eldrix/hermes/core.clj
@@ -638,15 +638,15 @@
     (= :owl mode)
     (if-let [r @reasoner]
       (let [ctu-a (->ctu a), ctu-b (->ctu b)]
-        (scg/validate st ctu-a)
-        (scg/validate st ctu-b)
+        (when (or (not (scg/valid? st ctu-a)) (not (scg/valid? st ctu-b)))
+          (throw (ex-info "Invalid expression" {:a a :b b})))
         (reasoner/subsumes? r (scg/ctu->cf ctu-a) (scg/ctu->cf ctu-b)))
       (throw (ex-info "OWL reasoning unavailable" {:mode mode})))
 
     :else
     (let [ctu-a (->ctu a), ctu-b (->ctu b)]
-      (scg/validate st ctu-a)
-      (scg/validate st ctu-b)
+      (when (or (not (scg/valid? st ctu-a)) (not (scg/valid? st ctu-b)))
+        (throw (ex-info "Invalid expression" {:a a :b b})))
       (subsumes-ctu st ctu-a ctu-b))))
 
 (s/fdef classify-expression
@@ -663,7 +663,8 @@
   [{st :store reasoner :reasoner} expression & {:as _opts}]
   (if-let [r @reasoner]
     (let [ctu (->ctu expression)]
-      (scg/validate st ctu)
+      (when-not (scg/valid? st ctu)
+        (throw (ex-info "Invalid expression" {:expression expression})))
       (reasoner/classify r (scg/ctu->cf ctu)))
     (throw (ex-info "OWL reasoning unavailable" {}))))
 
@@ -681,7 +682,8 @@
   [{st :store reasoner :reasoner} expression & {:as _opts}]
   (if-let [r @reasoner]
     (let [ctu (->ctu expression)]
-      (scg/validate st ctu)
+      (when-not (scg/valid? st ctu)
+        (throw (ex-info "Invalid expression" {:expression expression})))
       (reasoner/necessary-normal-form r (scg/ctu->cf ctu)))
     (throw (ex-info "OWL reasoning unavailable" {}))))
 

--- a/src/com/eldrix/hermes/core.clj
+++ b/src/com/eldrix/hermes/core.clj
@@ -19,6 +19,7 @@
             [com.eldrix.hermes.impl.language :as lang]
             [com.eldrix.hermes.impl.members :as members]
             [com.eldrix.hermes.impl.mrcm :as mrcm]
+            [com.eldrix.hermes.impl.reasoner :as reasoner]
             [com.eldrix.hermes.impl.scg :as scg]
             [com.eldrix.hermes.impl.search :as search]
             [com.eldrix.hermes.impl.store :as store]
@@ -80,10 +81,13 @@
             ^IndexReader memberReader
             ^IndexSearcher memberSearcher
             localeMatchFn
-            mrcmDomainFn]
+            mrcmDomainFn
+            reasoner]                           ;; delay → Reasoner | nil
   Service
   Closeable
   (close [_]
+    (when-let [r (and reasoner (realized? reasoner) @reasoner)]
+      (.close ^Closeable r))
     (.close store)
     (.close indexReader)
     (.close memberReader)))
@@ -538,8 +542,112 @@
   [^Svc svc concept-ids parent-ids]
   (some (set parent-ids) (all-parents svc concept-ids)))
 
+(s/fdef parse-expression
+  :args (s/cat :svc ::svc :s string?)
+  :ret :ctu/expression)
+
 (defn parse-expression [^Svc _svc s]
-  (scg/parse s))
+  (scg/str->ctu s))
+
+(s/fdef activate-reasoner
+  :args (s/cat :svc ::svc)
+  :ret ::svc)
+
+(defn activate-reasoner
+  "Force initialization of the OWL reasoner. Returns the service unchanged.
+  Throws if the reasoner cannot be started. Call at startup to pay the
+  initialization cost upfront rather than on first query."
+  [svc]
+  (if @(:reasoner svc)
+    (do (log/info "OWL reasoner activated successfully") svc)
+    (throw (ex-info "OWL reasoning unavailable: check OWL libraries are on classpath and OWL data has been imported (use --owl during import)" {}))))
+
+(s/fdef reasoning-status
+  :args (s/cat :svc ::svc)
+  :ret #{:active :inactive :unavailable})
+
+(defn reasoning-status
+  "Return the current reasoning status without triggering initialization.
+  - :active      — reasoner is initialized and ready
+  - :inactive    — OWL classes and data are available but reasoner not yet started
+  - :unavailable — OWL libraries not on classpath or no OWL data in store"
+  [svc]
+  (let [r (:reasoner svc)]
+    (cond
+      (and r (realized? r) (some? @r))
+      :active
+
+      (reasoner/reasoning-available? (:store svc))
+      :inactive
+
+      :else
+      :unavailable)))
+
+(s/def ::mode #{:structural :owl})
+
+(s/fdef expression-subsumes?
+  :args (s/cat :svc ::svc
+               :a (s/or :string string? :ctu :ctu/expression)
+               :b (s/or :string string? :ctu :ctu/expression)
+               :opts (s/keys* :opt-un [::mode]))
+  :ret #{:equivalent :subsumes :subsumed-by :not-subsumed})
+
+(defn expression-subsumes?
+  "Does expression A subsume expression B?
+  Accepts SCG strings or parsed CTU expressions.
+  Uses structural subsumption by default. When :mode is :owl and a reasoner
+  is available, uses OWL reasoning; otherwise falls back to structural.
+
+  Returns :equivalent, :subsumes, :subsumed-by, or :not-subsumed."
+  [svc a b & {:keys [mode] :or {mode :structural}}]
+  (let [st (.-store ^Svc svc)
+        ctu-a (if (string? a) (scg/str->ctu a) a)
+        ctu-b (if (string? b) (scg/str->ctu b) b)]
+    (scg/validate st ctu-a)
+    (scg/validate st ctu-b)
+    (if-let [reasoner (and (= :owl mode) @(:reasoner svc))]
+      (reasoner/subsumes? reasoner (scg/ctu->cf ctu-a) (scg/ctu->cf ctu-b))
+      (let [cf-a (scg/ctu->cf+normalize st ctu-a)
+            cf-b (scg/ctu->cf+normalize st ctu-b)
+            a-subsumes-b (scg/cf-subsumes? st cf-a cf-b)
+            b-subsumes-a (scg/cf-subsumes? st cf-b cf-a)]
+        (cond
+          (and a-subsumes-b b-subsumes-a) :equivalent
+          a-subsumes-b                    :subsumes
+          b-subsumes-a                    :subsumed-by
+          :else                           :not-subsumed)))))
+
+(s/fdef classify-expression
+  :args (s/cat :svc ::svc :expression (s/or :string string? :ctu :ctu/expression))
+  :ret (s/nilable map?))
+
+(defn classify-expression
+  "Classify a post-coordinated expression using OWL reasoning.
+  Accepts an SCG string or parsed CTU expression.
+  Returns a map with ::owl/equivalent-concepts, ::owl/direct-super-concepts,
+  and ::owl/proximal-primitive-supertypes, or nil if reasoning is unavailable."
+  [svc expression]
+  (when-let [reasoner @(:reasoner svc)]
+    (let [st (.-store ^Svc svc)
+          ctu (if (string? expression) (scg/str->ctu expression) expression)]
+      (scg/validate st ctu)
+      (reasoner/classify reasoner (scg/ctu->cf ctu)))))
+
+(s/fdef necessary-normal-form
+  :args (s/cat :svc ::svc :expression (s/or :string string? :ctu :ctu/expression))
+  :ret (s/nilable :cf/expression))
+
+(defn necessary-normal-form
+  "Compute the Necessary Normal Form of an expression using OWL reasoning.
+  Accepts an SCG string or parsed CTU expression.
+  Returns a CF expression with proximal primitive supertypes as focus
+  concepts plus all necessary relationships, or nil if unavailable."
+  [svc expression]
+  (when-let [reasoner @(:reasoner svc)]
+    (let [st (.-store ^Svc svc)
+          ctu (if (string? expression) (scg/str->ctu expression) expression)]
+      (scg/validate st ctu)
+      (reasoner/necessary-normal-form reasoner (scg/ctu->cf ctu)))))
 
 (defn ^:private make-search-params
   [^Svc svc {:keys [s query constraint accept-language language-refset-ids] :as params}]
@@ -1221,7 +1329,8 @@
               :searcher       index-searcher
               :memberReader   member-reader
               :memberSearcher (IndexSearcher. member-reader)
-              :localeMatchFn  locale-match-fn}]
+              :localeMatchFn  locale-match-fn
+              :reasoner       (delay (reasoner/start-reasoner st))}]
      ;; report configuration when appropriate
      (when-not quiet
        (let [lang-refset-ids (locale-match-fn)]
@@ -1236,16 +1345,17 @@
 
 (s/fdef do-import-snomed
   :args (s/cat :store-file any?
-               :files (s/coll-of :info.snomed/ReleaseFile)))
+               :files (s/coll-of :info.snomed/ReleaseFile)
+               :opts (s/nilable map?)))
 (defn- do-import-snomed
   "Import a SNOMED distribution from the specified files into a local
    file-based database `store-file`.
    Blocking; will return when done. Throws an exception on the calling thread if
    there are any import problems."
-  [store-file files]
+  [store-file files opts]
   (with-open [store (store/open-store store-file {:read-only? false})]
-    (let [nthreads (.availableProcessors (Runtime/getRuntime))
-          data-c (importer/load-snomed-files files :nthreads nthreads)]
+    (let [opts (update opts :nthreads #(or % (.availableProcessors (Runtime/getRuntime))))
+          data-c (importer/load-snomed-files files opts)]
       (loop [batch (a/<!! data-c)]
         (when batch
           (if (instance? Throwable batch)
@@ -1282,8 +1392,10 @@
     3. import of non-core and extension files.
 
   Interim indexing is necessary in order to ensure correct reification in
-  subsequent import(s)."
-  [root dirs]
+  subsequent import(s).
+
+  Options are passed through to [[importer/load-snomed-files]]."
+  [root dirs & {:as opts}]
   (let [manifest (open-manifest root true)
         store-file (io/file root (:store manifest))]
     (doseq [dir dirs]
@@ -1291,10 +1403,10 @@
       (let [files (importer/importable-files dir)]
         (if (seq files)
           (do
-            (do-import-snomed store-file (->> files (filter #(core-components (:component %)))))
+            (do-import-snomed store-file (->> files (filter #(core-components (:component %)))) opts)
             (with-open [st (store/open-store store-file {:read-only? false})]
               (store/index st))
-            (do-import-snomed store-file (->> files (remove #(core-components (:component %))))))
+            (do-import-snomed store-file (->> files (remove #(core-components (:component %)))) opts))
           (log/warn "no importable files found when processing:" dir))))))
 
 (defn compact

--- a/src/com/eldrix/hermes/core.clj
+++ b/src/com/eldrix/hermes/core.clj
@@ -624,8 +624,8 @@
 (defn classify-expression
   "Classify a post-coordinated expression using OWL reasoning.
   Accepts an SCG string or parsed CTU expression.
-  Returns a map with ::owl/equivalent-concepts, ::owl/direct-super-concepts,
-  and ::owl/proximal-primitive-supertypes, or nil if reasoning is unavailable."
+  Returns a map with :equivalent-concepts, :direct-super-concepts,
+  and :proximal-primitive-supertypes, or nil if reasoning is unavailable."
   [svc expression]
   (when-let [reasoner @(:reasoner svc)]
     (let [st (.-store ^Svc svc)

--- a/src/com/eldrix/hermes/impl/mrcm.clj
+++ b/src/com/eldrix/hermes/impl/mrcm.clj
@@ -1,4 +1,4 @@
-; Copyright (c) 2020-2024 Mark Wardle and Eldrix Ltd
+; Copyright (c) 2020-2026 Mark Wardle and Eldrix Ltd
 ;
 ; This program and the accompanying materials are made available under the
 ; terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +10,8 @@
   "MRCM (Machine Readable Concept Model) operations.
   Provides attribute domain and range lookups for validating SNOMED CT
   expressions against MRCM constraints."
-  (:require [com.eldrix.hermes.impl.ecl :as ecl]
+  (:require [clojure.spec.alpha :as s]
+            [com.eldrix.hermes.impl.ecl :as ecl]
             [com.eldrix.hermes.impl.members :as members]
             [com.eldrix.hermes.impl.search :as search]
             [com.eldrix.hermes.impl.store :as store]
@@ -29,6 +30,9 @@
                (map :mrcmRuleRefsetId)
                (filter #(store/is-a? store % type-id)))
          (members/search memberSearcher (members/q-refset-id snomed/MRCMModuleScopeReferenceSet)))))
+
+(s/fdef domains
+  :ret (s/coll-of :info.snomed/MRCMDomainRefset))
 
 (defn domains
   "Return a sequence of MRCM Domain reference set items."

--- a/src/com/eldrix/hermes/impl/owl.clj
+++ b/src/com/eldrix/hermes/impl/owl.clj
@@ -1,0 +1,730 @@
+; Copyright (c) 2020-2026 Mark Wardle and Eldrix Ltd
+;
+; This program and the accompanying materials are made available under the
+; terms of the Eclipse Public License 2.0 which is available at
+; http://www.eclipse.org/legal/epl-2.0.
+;
+; SPDX-License-Identifier: EPL-2.0
+;;;;
+(ns ^:no-doc com.eldrix.hermes.impl.owl
+  "OWL reasoning support for SNOMED CT.
+  Converts classifiable form (CF) expressions to OWL API objects and provides
+  ELK reasoner integration for classification and subsumption testing."
+  (:require [clojure.core.async :as a]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [com.eldrix.hermes.impl.scg :as scg]
+            [com.eldrix.hermes.impl.store :as store]
+            [com.eldrix.hermes.snomed :as snomed])
+  (:import (java.io Closeable)
+           (java.util Set UUID)
+           (java.util.concurrent.locks ReentrantLock)
+           (org.semanticweb.owlapi.apibinding OWLManager)
+           (org.semanticweb.owlapi.functional.parser OWLFunctionalSyntaxOWLParser)
+           (org.semanticweb.owlapi.io StringDocumentSource)
+           (org.semanticweb.owlapi.model AxiomType IRI OWLAxiom OWLClass OWLClassExpression
+                                         OWLDataFactory OWLOntology
+                                         OWLOntologyLoaderConfiguration
+                                         OWLOntologyManager
+                                         OWLSubPropertyChainOfAxiom
+                                         OWLTransitiveObjectPropertyAxiom)
+           (org.semanticweb.owlapi.reasoner OWLReasoner InferenceType)
+           (org.semanticweb.owlapi.util DefaultPrefixManager)
+           (org.semanticweb.owlapi.vocab OWL2Datatype)
+           (org.semanticweb.elk.owlapi ElkReasonerFactory)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private snomed-iri "http://snomed.info/id/")
+
+;;;; ── Specs ──
+
+(s/def ::equivalent-concepts (s/coll-of :info.snomed.Concept/id :kind set?))
+(s/def ::direct-super-concepts (s/coll-of :info.snomed.Concept/id :kind set?))
+(s/def ::proximal-primitive-supertypes (s/coll-of :info.snomed.Concept/id :kind set?))
+(s/def ::classification-result
+  (s/keys :req [::equivalent-concepts ::direct-super-concepts ::proximal-primitive-supertypes]))
+
+;;;; ── CF → OWL API ──
+
+(declare cf-value->owl-class-expression)
+
+(defn- cf-attribute->owl-expression
+  "Convert a CF attribute [type-id [tag value]] to an OWL expression.
+  Concept values become ObjectSomeValuesFrom, concrete values become DataHasValue."
+  [^OWLDataFactory factory ^DefaultPrefixManager pm [type-id [tag value]]]
+  (let [obj-prop #(.getOWLObjectProperty factory (str ":" type-id) pm)
+        data-prop #(.getOWLDataProperty factory (str ":" type-id) pm)]
+    (case tag
+      :concept
+      (.getOWLObjectSomeValuesFrom factory (obj-prop)
+        (.getOWLClass factory (str ":" value) pm))
+
+      :expression
+      (.getOWLObjectSomeValuesFrom factory (obj-prop)
+        (cf-value->owl-class-expression factory pm value))
+
+      :numeric
+      (.getOWLDataHasValue factory (data-prop)
+        (if (integer? value)
+          (.getOWLLiteral factory (str value) OWL2Datatype/XSD_INTEGER)
+          (.getOWLLiteral factory (str value) OWL2Datatype/XSD_DECIMAL)))
+
+      :string
+      (.getOWLDataHasValue factory (data-prop)
+        (.getOWLLiteral factory ^String value))
+
+      :boolean
+      (.getOWLDataHasValue factory (data-prop)
+        (.getOWLLiteral factory (boolean value))))))
+
+(defn- make-intersection-or-single
+  "If the collection has one element, return it. Otherwise wrap in ObjectIntersectionOf."
+  [^OWLDataFactory factory exprs]
+  (if (= 1 (count exprs))
+    (first exprs)
+    (.getOWLObjectIntersectionOf factory ^Set (set exprs))))
+
+(defn- cf-group->role-group
+  "Convert a CF group (set of attributes) to a role-group-wrapped expression.
+  ObjectSomeValuesFrom(:609096000 ObjectIntersectionOf(...))"
+  [^OWLDataFactory factory ^DefaultPrefixManager pm group]
+  (let [group-exprs (mapv #(cf-attribute->owl-expression factory pm %) group)]
+    (.getOWLObjectSomeValuesFrom factory
+      (.getOWLObjectProperty factory (str ":" snomed/RoleGroup) pm)
+      ^OWLClassExpression (make-intersection-or-single factory group-exprs))))
+
+(defn- cf-value->owl-class-expression
+  "Build the OWL class expression for the right-hand side of a CF expression."
+  ^OWLClassExpression [^OWLDataFactory factory ^DefaultPrefixManager pm cf-expression]
+  (let [{:cf/keys [focus-concepts ungrouped groups]} cf-expression
+        top-level (concat
+                    (map #(.getOWLClass factory (str ":" %) pm) focus-concepts)
+                    (when ungrouped (map #(cf-attribute->owl-expression factory pm %) ungrouped))
+                    (when groups (map #(cf-group->role-group factory pm %) groups)))]
+    (make-intersection-or-single factory top-level)))
+
+(defn cf->axiom
+  "Convert a classifiable form expression to an OWLAxiom.
+
+  The concept-id becomes the left-hand side. The CF expression provides the
+  right-hand side: focus concepts become OWLClass references, ungrouped
+  attributes become ObjectSomeValuesFrom, and groups are wrapped in
+  ObjectSomeValuesFrom with the role group concept (609096000).
+
+  Returns an OWLSubClassOfAxiom or OWLEquivalentClassesAxiom."
+  [^OWLDataFactory factory ^DefaultPrefixManager pm concept-id cf-expression]
+  (let [lhs (.getOWLClass factory (str ":" concept-id) pm)
+        rhs (cf-value->owl-class-expression factory pm cf-expression)]
+    (if (= :subtype-of (:cf/definition-status cf-expression))
+      (.getOWLSubClassOfAxiom factory lhs rhs)
+      (.getOWLEquivalentClassesAxiom factory ^OWLClassExpression lhs ^OWLClassExpression rhs))))
+
+;;;; ── OWL String Parsing / Rendering ──
+
+(def ^:private ontology-doc-start "Prefix(:=<http://snomed.info/id/>) Ontology(")
+(def ^:private ontology-doc-end ")")
+
+(defn create-axiom-deserializer
+  "Create a single-threaded OWL axiom deserializer. Returns a function that
+  takes an OWL functional syntax string and returns the parsed OWLAxiom."
+  []
+  (let [manager  (OWLManager/createOWLOntologyManager)
+        ontology (.loadOntologyFromOntologyDocument
+                   manager (StringDocumentSource. (str ontology-doc-start ontology-doc-end)))
+        config   (OWLOntologyLoaderConfiguration.)
+        parser   (OWLFunctionalSyntaxOWLParser.)]
+    (fn deserialize [^String owl-expression]
+      (when (str/blank? owl-expression)
+        (throw (ex-info "OWL expression is blank" {:owl-expression owl-expression})))
+      (let [expr (.replaceAll owl-expression "\\broleGroup\\b" "609096000")
+            doc  (str ontology-doc-start expr ontology-doc-end)]
+        (.parse parser (StringDocumentSource. doc) ontology config)
+        (let [axioms (.getAxioms ontology)]
+          (when (empty? axioms)
+            (throw (ex-info "OWL expression produced no axiom"
+                            {:owl-expression owl-expression})))
+          (let [axiom (first axioms)]
+            (.removeAxioms ontology axioms)
+            axiom))))))
+
+(defn axiom->owl-string
+  "Render an OWLAxiom to SNOMED OWL functional syntax with short-form IRIs.
+  Matches the approach used by the SNOMED OWL Toolkit's `axiomToString`:
+  https://github.com/IHTSDO/snomed-owl-toolkit/blob/master/src/main/java/org/snomed/otf/owltoolkit/conversion/AxiomRelationshipConversionService.java#L297"
+  [^OWLAxiom axiom]
+  (-> (.toString axiom)
+      (.replaceAll "<http://snomed.info/id/([0-9]+)>" ":$1")
+      (.replaceAll "\\)\\s+\\)" "))")))
+
+;;;; ── Property Chains ──
+
+(defn- parse-property-id
+  "Extract a SNOMED concept ID from an OWL object property IRI, or nil."
+  [^org.semanticweb.owlapi.model.OWLObjectPropertyExpression prop]
+  (let [iri (str (.getIRI (.asOWLObjectProperty (.getNamedProperty prop))))
+        id-str (.replace ^String iri ^String snomed-iri "")]
+    (when (re-matches #"\d+" id-str)
+      (Long/parseLong id-str))))
+
+(defn extract-property-chains
+  "Extract property chains and transitive properties from an OWL ontology.
+  Returns a map of {inferred-type-id #{[source-type-id dest-type-id] ...}}.
+
+  Sources:
+  - SubPropertyChainOf(ObjectPropertyChain(A B) C) => {C #{[A B]}}
+  - TransitiveObjectProperty(P) => {P #{[P P]}}"
+  [^OWLOntology ontology]
+  (let [chains (atom {})]
+    (doseq [^OWLSubPropertyChainOfAxiom ax (.getAxioms ontology AxiomType/SUB_PROPERTY_CHAIN_OF)]
+      (let [chain (.getPropertyChain ax)
+            super-id (parse-property-id (.getSuperProperty ax))
+            chain-ids (mapv parse-property-id chain)]
+        (when (and super-id (every? some? chain-ids) (= 2 (count chain-ids)))
+          (swap! chains update super-id (fnil conj #{}) (vec chain-ids)))))
+    (doseq [^OWLTransitiveObjectPropertyAxiom ax (.getAxioms ontology AxiomType/TRANSITIVE_OBJECT_PROPERTY)]
+      (when-let [prop-id (parse-property-id (.getProperty ax))]
+        (swap! chains update prop-id (fnil conj #{}) [prop-id prop-id])))
+    @chains))
+
+;;;; ── NNF (pure functions) ──
+
+(defn- chain-redundant?
+  "True if attribute `attr` in `group` is redundant due to a property chain.
+  `property-chains` is {inferred-type #{[source dest] ...}}.
+  `rel-targets-fn` is (fn [concept-id type-id] => #{target-ids}) — returns
+  the target concepts for a given relationship type on a concept.
+  `is-a-fn` is (fn [child parent] => boolean)."
+  [property-chains rel-targets-fn is-a-fn group [type-id [tag value-id] :as attr]]
+  (when (and (= :concept tag) (contains? property-chains type-id))
+    (some (fn [[source-type dest-type]]
+            (some (fn [[other-type [other-tag other-value]]]
+                    (when (and (= :concept other-tag)
+                               (= other-type source-type))
+                      (let [targets (rel-targets-fn other-value dest-type)]
+                        (or (contains? targets value-id)
+                            (some #(is-a-fn value-id %) targets)))))
+                  (disj group attr)))
+          (get property-chains type-id))))
+
+(defn compute-nnf
+  "Compute the Necessary Normal Form from pre-collected classification data.
+
+  Parameters:
+  - pps-ids         : set of proximal primitive supertype concept IDs
+  - cf-expression   : input CF expression (carries user-supplied refinements)
+  - inherited-attrs : {:ungrouped #{...} :groups #{...}} collected from PPSs
+  - opts map:
+    :reduce-attrs   — (fn [attrs] => attrs') — Rule 1 within-group redundancy
+    :reduce-groups  — (fn [groups] => groups') — Rule 1 cross-group redundancy
+    :chains         — {type-id #{[source dest] ...}} property chain rules
+    :rel-targets    — (fn [concept-id type-id] => #{target-ids})
+    :is-a?          — (fn [child-id parent-id] => boolean)
+
+  Returns a CF expression with :cf/definition-status :subtype-of."
+  [pps-ids cf-expression inherited-attrs
+   {:keys [reduce-attrs reduce-groups chains rel-targets is-a?]
+    :or   {reduce-attrs identity reduce-groups identity
+           chains {} rel-targets (constantly #{}) is-a? (constantly false)}}]
+  (let [;; 1. Merge inherited + user-supplied
+        all-ungrouped (into (:ungrouped inherited-attrs) (:cf/ungrouped cf-expression))
+        all-groups    (into (:groups inherited-attrs) (:cf/groups cf-expression))
+        ;; 2. Rule 1: type/value subsumption redundancy
+        all-ungrouped (reduce-attrs all-ungrouped)
+        all-groups    (->> all-groups
+                          (into #{} (map #(set (reduce-attrs %))))
+                          reduce-groups)
+        ;; 3. Rule 2: property chain redundancy within groups
+        property-chains chains
+        all-groups    (if (seq property-chains)
+                        (->> all-groups
+                             (into #{} (comp
+                                         (map (fn [g]
+                                                (into #{} (remove #(chain-redundant? property-chains
+                                                                                     rel-targets is-a? g %))
+                                                      g)))
+                                         (filter seq))))
+                        all-groups)]
+    (cond-> {:cf/definition-status :subtype-of
+             :cf/focus-concepts    pps-ids}
+      (seq all-ungrouped) (assoc :cf/ungrouped all-ungrouped)
+      (seq all-groups)    (assoc :cf/groups all-groups))))
+
+(defn collect-inherited-attributes
+  "Collect inferred non-IS-A relationships from the store for a set of concept IDs.
+  The store contains inferred relationships from the RF2 distribution — these
+  are the complete NNF for each pre-coordinated concept, already computed by the
+  OWL Toolkit. No ancestor walking is needed.
+  Returns {:ungrouped #{...} :groups #{...}}."
+  [store concept-ids]
+  (reduce
+    (fn [acc concept-id]
+      (let [{:keys [ungrouped groups]} (scg/properties->attributes
+                                         (store/properties-by-group store concept-id))]
+        (-> acc
+            (update :ungrouped into ungrouped)
+            (update :groups into groups))))
+    {:ungrouped #{} :groups #{}}
+    concept-ids))
+
+;;;; ── Service Layer ──
+
+(defn build-ontology-from-store
+  "Build an OWLOntology by streaming all refset items from the store, filtering
+  for active OWL expression items, and parsing them in parallel.
+
+  Spawns n-parsers worker threads, each with its own deserializer, all draining
+  a shared expression channel. Parsed axioms are sent to an output channel and
+  added to the ontology on the calling thread.
+
+  Parameters:
+  - store : an open hermes store
+  - opts  : optional map
+    :n-parsers   — parallel parser threads (default 8)
+    :item-filter — predicate on OWLExpressionRefsetItem (default: identity)"
+  (^OWLOntology [store] (build-ontology-from-store store {}))
+  (^OWLOntology [store {:keys [n-parsers item-filter]
+                        :or   {n-parsers 8 item-filter identity}}]
+   (let [expr-ch  (a/chan 8192 (comp (filter #(instance? com.eldrix.hermes.snomed.OWLExpressionRefsetItem %))
+                                     (filter :active)
+                                     (remove #(= snomed/OWLOntologyReferenceSet (:refsetId %)))
+                                     (filter item-filter)
+                                     (map :owlExpression)))
+         axiom-ch (a/chan 64 (partition-all 512))
+         errors   (atom [])
+         manager  (OWLManager/createOWLOntologyManager)
+         ontology (.createOntology manager)
+         ;; spawn n workers, each with own deserializer, draining the shared expr-ch
+         done-chs (into [] (repeatedly n-parsers
+                            #(a/thread
+                               (let [parse (create-axiom-deserializer)]
+                                 (loop []
+                                   (when-let [owl-expr (a/<!! expr-ch)]
+                                     (try
+                                       (a/>!! axiom-ch (parse owl-expr))
+                                       (catch Exception ex
+                                         (log/error ex "failed to parse OWL expression")
+                                         (swap! errors conj ex)))
+                                     (recur)))))))]
+     (log/info "loading OWL axioms from store...")
+     (a/thread
+       (try
+         (store/stream-all-refset-items store expr-ch)
+         (catch Exception e
+           (log/error e "failed to stream refset items")
+           (a/close! expr-ch))))
+     ;; close axiom-ch once all workers complete
+     (a/go
+       (doseq [ch done-chs] (a/<! ch))
+       (a/close! axiom-ch))
+     (loop [n 0]
+       (if-let [batch (a/<!! axiom-ch)]
+         (do (.addAxioms ontology ^java.util.Collection batch)
+             (recur (+ n (count batch))))
+         (let [errs @errors]
+           (when (seq errs)
+             (log/warn (count errs) "OWL axiom(s) failed to parse"))
+           (log/info "loaded" n "OWL axioms into ontology")
+           (when (and (zero? n) (seq errs))
+             (throw (ex-info "All OWL axioms failed to parse"
+                             {:error-count (count errs)
+                              :first-error (first errs)})))
+           ontology))))))
+
+(defn create-reasoner
+  "Create an ELK reasoner and run initial classification.
+  This is the expensive step (~30s-5min depending on SNOMED edition size).
+  Returns the OWLReasoner instance."
+  ^OWLReasoner [^OWLOntology ontology]
+  (log/info "classifying ontology...")
+  (let [reasoner-factory (ElkReasonerFactory.)
+        reasoner         (.createReasoner reasoner-factory ontology)]
+    (.precomputeInferences reasoner
+      (into-array InferenceType [InferenceType/CLASS_HIERARCHY]))
+    reasoner))
+
+(def ^:private temp-iri-prefix "http://snomed.info/temp/classify/")
+
+(defprotocol Reasoner
+  "Protocol for OWL reasoning over SNOMED CT expressions."
+  (-classify [this cf-expression]
+    "Classify a CF expression. Returns a ::classification-result map with
+    ::equivalent-concepts, ::direct-super-concepts, and ::proximal-primitive-supertypes.")
+  (-subsumes? [this cf-a cf-b]
+    "Test subsumption between two CF expressions. Returns one of:
+    :equivalent, :subsumes, :subsumed-by, :not-subsumed.
+    Aligns with the FHIR CodeSystem $subsumes operation.")
+  (-necessary-normal-form [this cf-expression]
+    "Return the Necessary Normal Form of a CF expression after classification.
+    The NNF expresses the concept in terms of its proximal primitive supertypes
+    plus all necessary role relationships. Returns a CF expression with
+    :cf/definition-status :subtype-of and :cf/focus-concepts set to the
+    proximal primitive supertypes.")
+  (-close [this]
+    "Release resources held by the reasoner."))
+
+(s/def ::reasoner #(satisfies? Reasoner %))
+
+(defn- parse-iri->concept-id
+  "Extract a SNOMED concept ID from an OWL class IRI, or nil."
+  [^OWLClass cls]
+  (let [iri (str (.getIRI cls))
+        id-str (.replace ^String iri ^String snomed-iri "")]
+    (when (re-matches #"\d+" id-str)
+      (Long/parseLong id-str))))
+
+(defn- make-temp-axiom
+  "Build a temporary OWL axiom for a CF expression.
+  Returns {:temp-cls OWLClass, :axiom OWLAxiom}."
+  [^OWLDataFactory factory ^DefaultPrefixManager pm cf-expression]
+  (let [temp-iri (IRI/create (str temp-iri-prefix (UUID/randomUUID)))
+        temp-cls (.getOWLClass factory temp-iri)
+        rhs      (cf-value->owl-class-expression factory pm cf-expression)
+        axiom    (if (= :subtype-of (:cf/definition-status cf-expression))
+                   (.getOWLSubClassOfAxiom factory temp-cls rhs)
+                   (.getOWLEquivalentClassesAxiom factory
+                     ^OWLClassExpression temp-cls ^OWLClassExpression rhs))]
+    {:temp-cls temp-cls :axiom axiom}))
+
+(defn- primitive-class?
+  "A concept is primitive if it has no EquivalentClasses axiom in the ontology."
+  [^OWLOntology ontology ^OWLClass cls]
+  (empty? (.getEquivalentClassesAxioms ontology cls)))
+
+(defn- proximal-primitive-supertypes
+  "Walk the inferred hierarchy upward from `cls`, skipping defined (fully-defined)
+  concepts and collecting only the most specific (proximal) primitive ancestors.
+  A concept is primitive when it has no EquivalentClasses axiom in the ontology.
+  After collecting all reachable primitive ancestors, non-proximal ones (those
+  subsumed by another in the set) are removed."
+  [^OWLOntology ontology ^OWLReasoner reasoner ^OWLClass cls]
+  (let [all-primitives
+        (loop [queue (into clojure.lang.PersistentQueue/EMPTY
+                           (.getFlattened (.getSuperClasses reasoner cls true)))
+               result #{}]
+          (if-let [^OWLClass super (peek queue)]
+            (cond
+              (.isOWLThing super)
+              (recur (pop queue) result)
+
+              (primitive-class? ontology super)
+              (recur (pop queue) (conj result super))
+
+              :else ;; defined — skip through to its supers
+              (recur (into (pop queue) (.getFlattened (.getSuperClasses reasoner super true)))
+                     result))
+            result))]
+    ;; Remove non-proximal: if A is a superclass of B, keep B (more specific)
+    (into #{} (remove (fn [^OWLClass candidate]
+                        (some (fn [^OWLClass other]
+                                (and (not= candidate other)
+                                     (.containsEntity
+                                       (.getSuperClasses reasoner other false)
+                                       candidate)))
+                              all-primitives))
+                      all-primitives))))
+
+(defn- query-classification
+  "Query the reasoner for equivalent classes, direct super classes, and
+  proximal primitive supertypes of a temp class."
+  [^OWLOntology ontology ^OWLReasoner reasoner ^OWLClass temp-cls]
+  (let [equivalents (->> (.getEquivalentClasses reasoner temp-cls)
+                         (.getEntities)
+                         (remove (fn [^OWLClass c] (.isOWLNothing c)))
+                         (keep parse-iri->concept-id)
+                         set)
+        supers     (->> (.getSuperClasses reasoner temp-cls true)
+                        (.getFlattened)
+                        (remove (fn [^OWLClass c] (.isOWLThing c)))
+                        (keep parse-iri->concept-id)
+                        set)
+        primitives (->> (proximal-primitive-supertypes ontology reasoner temp-cls)
+                        (keep parse-iri->concept-id)
+                        set)]
+    {::equivalent-concepts equivalents
+     ::direct-super-concepts supers
+     ::proximal-primitive-supertypes primitives}))
+
+(defn- with-temp-axioms
+  "Create temporary axioms from CF expressions, add them to the ontology, flush
+  the reasoner, call f with a vector of the temporary OWLClass instances, then
+  remove the axioms and flush again. Acquires the lock for thread safety."
+  [^OWLOntology ontology ^OWLDataFactory factory ^DefaultPrefixManager pm
+   ^OWLReasoner reasoner ^ReentrantLock lock cf-expressions f]
+  (let [temps  (mapv #(make-temp-axiom factory pm %) cf-expressions)
+        axioms (mapv :axiom temps)]
+    (.lock lock)
+    (try
+      (.addAxioms ontology ^java.util.Collection axioms)
+      (try
+        (.flush reasoner)
+        (f (mapv :temp-cls temps))
+        (finally
+          (try
+            (.removeAxioms ontology ^java.util.Collection axioms)
+            (catch Exception e
+              (log/error e "failed to remove temporary axioms")))
+          (try
+            (.flush reasoner)
+            (catch Exception e
+              (log/error e "failed to flush reasoner after cleanup")))))
+      (finally
+        (.unlock lock)))))
+
+(defrecord SimpleReasoner
+  [^OWLOntology ontology
+   ^OWLDataFactory factory
+   ^DefaultPrefixManager prefix-manager
+   ^OWLReasoner reasoner
+   ^ReentrantLock lock
+   store
+   property-chains]
+  Reasoner
+  (-classify [_ cf-expression]
+    (with-temp-axioms ontology factory prefix-manager reasoner lock [cf-expression]
+      (fn [[^OWLClass temp-cls]]
+        (query-classification ontology reasoner temp-cls))))
+  (-subsumes? [_ cf-a cf-b]
+    (with-temp-axioms ontology factory prefix-manager reasoner lock [cf-a cf-b]
+      (fn [[^OWLClass a-cls ^OWLClass b-cls]]
+        (let [a-subs-b (.containsEntity (.getSuperClasses reasoner b-cls false) a-cls)
+              b-subs-a (.containsEntity (.getSuperClasses reasoner a-cls false) b-cls)
+              equiv    (.contains (.getEquivalentClasses reasoner a-cls) b-cls)]
+          (cond
+            equiv    :equivalent
+            a-subs-b :subsumes
+            b-subs-a :subsumed-by
+            :else    :not-subsumed)))))
+  (-necessary-normal-form [_ cf-expression]
+    (with-temp-axioms ontology factory prefix-manager reasoner lock [cf-expression]
+      (fn [[^OWLClass temp-cls]]
+        (let [pps-ids   (->> (proximal-primitive-supertypes ontology reasoner temp-cls)
+                             (keep parse-iri->concept-id) set)
+              inherited (collect-inherited-attributes store (:cf/focus-concepts cf-expression))]
+          (compute-nnf pps-ids cf-expression inherited
+                       {:reduce-attrs  #(scg/remove-subsumed-attributes store %)
+                        :reduce-groups #(scg/remove-subsumed-groups store %)
+                        :chains        property-chains
+                        :rel-targets   #(store/parent-relationships-of-type store %1 %2)
+                        :is-a?         #(store/is-a? store %1 %2)})))))
+  (-close [_] (.dispose reasoner))
+  Closeable
+  (close [this] (-close this)))
+
+;;;; ── Public API ──
+
+(s/fdef classify
+  :args (s/cat :reasoner ::reasoner :cf-expression :cf/expression)
+  :ret ::classification-result)
+
+(defn classify
+  "Classify a CF expression against the loaded ontology.
+  Returns a ::classification-result map with ::equivalent-concepts,
+  ::direct-super-concepts, and ::proximal-primitive-supertypes."
+  [reasoner cf-expression]
+  (-classify reasoner cf-expression))
+
+(s/fdef subsumes?
+  :args (s/cat :reasoner ::reasoner :cf-a :cf/expression :cf-b :cf/expression)
+  :ret #{:equivalent :subsumes :subsumed-by :not-subsumed})
+
+(defn subsumes?
+  "Test subsumption between two CF expressions. Returns one of:
+  :equivalent, :subsumes, :subsumed-by, :not-subsumed.
+  Aligns with the FHIR CodeSystem $subsumes operation."
+  [reasoner cf-a cf-b]
+  (-subsumes? reasoner cf-a cf-b))
+
+(s/fdef necessary-normal-form
+  :args (s/cat :reasoner ::reasoner :cf-expression :cf/expression)
+  :ret :cf/expression)
+
+(defn necessary-normal-form
+  "Return the Necessary Normal Form (NNF) of a CF expression after classification.
+
+  The NNF expresses a concept/expression in terms of:
+  1. Proximal primitive supertypes — the most specific primitive ancestors in
+     the inferred hierarchy (from the OWL reasoner)
+  2. All necessary role relationships — inherited from the proximal primitive
+     supertypes plus user-supplied refinements, with redundancies removed
+
+  Redundancy removal applies two rules:
+  - Rule 1: attributes subsumed by a more specific attribute with the same type
+  - Rule 2: attributes implied by property chains (e.g., direct-substance ∘
+    is-modification-of → direct-substance)
+
+  Returns a CF expression with :cf/definition-status :subtype-of.
+
+  See: SNOMED OWL Toolkit RelationshipNormalFormGenerator"
+  [reasoner cf-expression]
+  (-necessary-normal-form reasoner cf-expression))
+
+(defn owl-available?
+  "True if the store contains OWL axiom data."
+  [store]
+  (contains? (store/installed-reference-sets store) snomed/OWLAxiomReferenceSet))
+
+(s/fdef start-reasoner
+  :args (s/cat :store any? :opts (s/? map?))
+  :ret (s/nilable ::reasoner))
+
+(defn start-reasoner
+  "Load OWL axioms from a hermes store and start the ELK reasoner.
+  Returns a Reasoner (satisfying Closeable), or nil if no OWL axioms found.
+
+  Parameters:
+  - store       : an open hermes store
+  - opts map (optional):
+    :n-parsers   — parallel parser threads (default 8)
+    :item-filter — predicate on OWLExpressionRefsetItem (default: identity)"
+  ([store] (start-reasoner store {}))
+  ([store opts]
+   (when (owl-available? store)
+     (let [ontology (build-ontology-from-store store opts)]
+       (when (pos? (.getAxiomCount ontology))
+         (let [reasoner (create-reasoner ontology)
+               factory  (.getOWLDataFactory (.getOWLOntologyManager ontology))
+               pm       (doto (DefaultPrefixManager.) (.setDefaultPrefix snomed-iri))
+               chains   (extract-property-chains ontology)]
+           (log/info "extracted" (count chains) "property chain rule(s) from ontology")
+           (->SimpleReasoner ontology factory pm reasoner (ReentrantLock.) store chains)))))))
+
+(defn stop-reasoner
+  "Dispose of the reasoner and release resources."
+  [reasoner]
+  (when reasoner
+    (-close reasoner)))
+
+;;;; ── ECL generation ──
+
+(declare cf->ecl*)
+
+(defn- cf-value->ecl
+  "Render a CF tagged attribute value as an ECL expression constraint.
+  Concept values use descendant-or-self (<<) for subsumption-aware matching."
+  [[tag value]]
+  (case tag
+    :concept    (str "<< " value)
+    :expression (str "(" (cf->ecl* value) ")")
+    :numeric    (str "#" value)
+    :string     (str "\"" (-> value
+                               (str/replace "\\" "\\\\")
+                               (str/replace "\"" "\\\"")) "\"")
+    :boolean    (if value "TRUE" "FALSE")))
+
+(defn- cf-attr->ecl
+  "Render a CF attribute [type-id [tag value]] as an ECL attribute constraint."
+  [[type-id value]]
+  (str type-id " = " (cf-value->ecl value)))
+
+(defn cf->ecl*
+  "Render a classifiable form expression as an ECL expression constraint string.
+  Focus concepts use descendant-or-self (<<), concept attribute values use
+  descendant-or-self (<<). Concrete values use exact match.
+
+  This is a pure rendering function — it does not invoke the reasoner. Use
+  [[cf->ecl]] for reasoner-informed ECL generation."
+  [{:cf/keys [focus-concepts ungrouped groups]}]
+  (let [foci       (sort focus-concepts)
+        focus-ecl  (if (= 1 (count foci))
+                     (str "<< " (first foci))
+                     (str "(" (str/join " AND " (map #(str "<< " %) foci)) ")"))
+        ungrouped-strs (when (seq ungrouped)
+                         (->> (sort-by first ungrouped)
+                              (map cf-attr->ecl)))
+        group-strs     (when (seq groups)
+                         (->> (sort-by #(apply min (map first %)) groups)
+                              (map (fn [g]
+                                     (str "{ "
+                                          (->> (sort-by first g)
+                                               (map cf-attr->ecl)
+                                               (str/join ", "))
+                                          " }")))))
+        all-refinements (concat ungrouped-strs group-strs)]
+    (if (seq all-refinements)
+      (str focus-ecl " : " (str/join ", " all-refinements))
+      focus-ecl)))
+
+(defn cf->ecl
+  "Generate an ECL expression constraint from a classifiable form expression
+  using OWL reasoning.
+
+  If the reasoner finds a pre-coordinated equivalent, returns `<< concept-id`.
+  Otherwise computes the Necessary Normal Form — proximal primitive supertypes
+  plus all necessary relationships — and renders it as an ECL refinement
+  constraint with descendant-or-self (<<) operators on concept values.
+
+  The resulting ECL, when evaluated against a SNOMED index, approximates
+  'all pre-coordinated concepts subsumed by this expression', informed by
+  the reasoner's classification rather than naive structural matching."
+  [reasoner cf-expression]
+  (let [result      (classify reasoner cf-expression)
+        equivalents (::equivalent-concepts result)]
+    (if (seq equivalents)
+      (str "<< " (first (sort equivalents)))
+      (cf->ecl* (necessary-normal-form reasoner cf-expression)))))
+
+
+(comment
+  (require '[com.eldrix.hermes.core :as hermes])
+  (require '[com.eldrix.hermes.impl.scg :as scg])
+  (def svc (hermes/open "snomed-owl.db"))
+  (def st (.-store svc))
+  (def reasoner (start-reasoner st))
+
+  ;; Equivalence discovery: express the definition of a fully-defined concept
+  ;; as a post-coordinated expression. The reasoner should find it equivalent
+  ;; to the pre-coordinated concept — something structural subsumption cannot do.
+  ;; Here we express appendectomy (80146002) via its defining relationships:
+  (classify reasoner (scg/ctu->cf (scg/str->ctu "80146002")))
+  ;; => ::equivalent-concepts should contain 80146002
+
+  ;; GCI-derived classification: clinical finding GCI axioms can infer parents
+  ;; beyond the focus concept. A disorder defined by finding site + morphology
+  ;; may be classified under a parent that isn't structurally obvious.
+  ;; e.g. "disorder of lung" with a specific morphology may be recognised as
+  ;; a specific named lung disease via GCI axioms:
+  (classify reasoner (scg/ctu->cf (scg/str->ctu
+    "64572001 |disease| : { 363698007 |finding site| = 39607008 |lung structure|, 116676008 |associated morphology| = 79654002 |edema| }")))
+
+  ;; "disease with finding site=femur and morphology=fracture" — the reasoner
+  ;; should infer this is a subtype of fracture of femur (71620000) via GCI
+  ;; axioms, not just a subtype of disease:
+  (classify reasoner (scg/ctu->cf (scg/str->ctu
+    "64572001 |disease| : { 363698007 |finding site| = 71341001 |bone structure of femur|, 116676008 |associated morphology| = 72704001 |fracture| }")))
+
+  ;; Necessary Normal Form: express an expression in terms of its proximal
+  ;; primitive supertypes + all inherited relationships. The NNF is always primitive.
+  (necessary-normal-form reasoner (scg/ctu->cf (scg/str->ctu "80146002")))
+  ;; => {:cf/definition-status :subtype-of
+  ;;     :cf/focus-concepts #{<primitive supers>}
+  ;;     :cf/groups #{#{[260686004 [:concept 129304002]] [405813007 [:concept 66754008]]}}}
+  ;; The groups now include inherited relationships from the concept's definition.
+
+  ;; NNF of a post-coordinated expression merges user refinements with inherited:
+  (necessary-normal-form reasoner (scg/ctu->cf (scg/str->ctu
+    "80146002 : 272741003 = 7771000")))
+  ;; The NNF includes laterality=left (user) + method/site groups (inherited)
+
+  ;; Subsumption testing (FHIR CodeSystem $subsumes):
+  (subsumes? reasoner
+    (scg/ctu->cf (scg/str->ctu "80146002"))
+    (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000")))
+  ;; => :subsumes
+
+  ;; ECL generation from SCG expressions:
+  ;; A fully-defined concept has a pre-coordinated equivalent:
+  (cf->ecl reasoner (scg/ctu->cf (scg/str->ctu "80146002")))
+  ;; => "<< 80146002"
+
+  ;; A post-coordinated expression has no equivalent — uses NNF:
+  (cf->ecl reasoner (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000")))
+  ;; => "<< prim1 : 272741003 = << 7771000, { ... }"
+
+  ;; Pure rendering without reasoner:
+  (cf->ecl* (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000")))
+  ;; => "<< 80146002 : 272741003 = << 7771000"
+
+  (stop-reasoner reasoner)
+  (hermes/close svc))

--- a/src/com/eldrix/hermes/impl/owl.clj
+++ b/src/com/eldrix/hermes/impl/owl.clj
@@ -44,7 +44,7 @@
 (s/def ::direct-super-concepts (s/coll-of :info.snomed.Concept/id :kind set?))
 (s/def ::proximal-primitive-supertypes (s/coll-of :info.snomed.Concept/id :kind set?))
 (s/def ::classification-result
-  (s/keys :req [::equivalent-concepts ::direct-super-concepts ::proximal-primitive-supertypes]))
+  (s/keys :req-un [::equivalent-concepts ::direct-super-concepts ::proximal-primitive-supertypes]))
 
 ;;;; ── CF → OWL API ──
 
@@ -349,8 +349,8 @@
 (defprotocol Reasoner
   "Protocol for OWL reasoning over SNOMED CT expressions."
   (-classify [this cf-expression]
-    "Classify a CF expression. Returns a ::classification-result map with
-    ::equivalent-concepts, ::direct-super-concepts, and ::proximal-primitive-supertypes.")
+    "Classify a CF expression. Returns a classification result map with
+    :equivalent-concepts, :direct-super-concepts, and :proximal-primitive-supertypes.")
   (-subsumes? [this cf-a cf-b]
     "Test subsumption between two CF expressions. Returns one of:
     :equivalent, :subsumes, :subsumed-by, :not-subsumed.
@@ -442,9 +442,9 @@
         primitives (->> (proximal-primitive-supertypes ontology reasoner temp-cls)
                         (keep parse-iri->concept-id)
                         set)]
-    {::equivalent-concepts equivalents
-     ::direct-super-concepts supers
-     ::proximal-primitive-supertypes primitives}))
+    {:equivalent-concepts equivalents
+     :direct-super-concepts supers
+     :proximal-primitive-supertypes primitives}))
 
 (defn- with-temp-axioms
   "Create temporary axioms from CF expressions, add them to the ontology, flush
@@ -520,8 +520,8 @@
 
 (defn classify
   "Classify a CF expression against the loaded ontology.
-  Returns a ::classification-result map with ::equivalent-concepts,
-  ::direct-super-concepts, and ::proximal-primitive-supertypes."
+  Returns a classification result map with :equivalent-concepts,
+  :direct-super-concepts, and :proximal-primitive-supertypes."
   [reasoner cf-expression]
   (-classify reasoner cf-expression))
 
@@ -660,7 +660,7 @@
   the reasoner's classification rather than naive structural matching."
   [reasoner cf-expression]
   (let [result      (classify reasoner cf-expression)
-        equivalents (::equivalent-concepts result)]
+        equivalents (:equivalent-concepts result)]
     (if (seq equivalents)
       (str "<< " (first (sort equivalents)))
       (cf->ecl* (necessary-normal-form reasoner cf-expression)))))
@@ -678,7 +678,7 @@
   ;; to the pre-coordinated concept — something structural subsumption cannot do.
   ;; Here we express appendectomy (80146002) via its defining relationships:
   (classify reasoner (scg/ctu->cf (scg/str->ctu "80146002")))
-  ;; => ::equivalent-concepts should contain 80146002
+  ;; => :equivalent-concepts should contain 80146002
 
   ;; GCI-derived classification: clinical finding GCI axioms can infer parents
   ;; beyond the focus concept. A disorder defined by finding site + morphology

--- a/src/com/eldrix/hermes/impl/reasoner.clj
+++ b/src/com/eldrix/hermes/impl/reasoner.clj
@@ -43,7 +43,7 @@
      (try
        ((dynaload 'com.eldrix.hermes.impl.owl/start-reasoner) store opts)
        (catch Exception e
-         (log/debug e "OWL reasoning not available")
+         (log/error e "failed to start OWL reasoner")
          nil)))))
 
 (defn classify

--- a/src/com/eldrix/hermes/impl/reasoner.clj
+++ b/src/com/eldrix/hermes/impl/reasoner.clj
@@ -1,0 +1,62 @@
+(ns ^:no-doc com.eldrix.hermes.impl.reasoner
+  "Classpath-safe facade for OWL reasoning.
+  Can be required unconditionally — does not import any OWL API or ELK classes.
+  Checks at runtime whether OWL libraries are on the classpath and delegates
+  to com.eldrix.hermes.impl.owl when they are."
+  (:require [clojure.tools.logging :as log]
+            [com.eldrix.hermes.impl.store :as store]
+            [com.eldrix.hermes.snomed :as snomed]))
+
+(defn- dynaload
+  "Lazily resolve a fully-qualified var symbol from an optional namespace.
+  Returns the var's value, or throws if the namespace cannot be loaded."
+  [qualified-sym]
+  (let [ns-sym (-> qualified-sym namespace symbol)]
+    (require ns-sym)
+    @(resolve qualified-sym)))
+
+(def ^:private owl-ns 'com.eldrix.hermes.impl.owl)
+
+(def owl-loaded?
+  "Delay that resolves to true if the impl.owl namespace can be loaded
+  (i.e. OWL API and ELK classes are on the classpath)."
+  (delay
+    (try (require owl-ns) true
+         (catch Throwable _ false))))
+
+(defn owl-data-available?
+  "True if the store contains OWL axiom reference set data."
+  [store]
+  (contains? (store/installed-reference-sets store) snomed/OWLAxiomReferenceSet))
+
+(defn reasoning-available?
+  "True if OWL libraries are on the classpath and OWL data is in the store."
+  [store]
+  (and @owl-loaded? (owl-data-available? store)))
+
+(defn start-reasoner
+  "Start an OWL reasoner from the given store, or nil if unavailable.
+  Returns nil if OWL libraries are not on the classpath or no OWL data exists."
+  ([store] (start-reasoner store {}))
+  ([store opts]
+   (when (reasoning-available? store)
+     (try
+       ((dynaload 'com.eldrix.hermes.impl.owl/start-reasoner) store opts)
+       (catch Exception e
+         (log/debug e "OWL reasoning not available")
+         nil)))))
+
+(defn classify
+  "Classify a CF expression against the loaded ontology."
+  [reasoner cf-expression]
+  ((dynaload 'com.eldrix.hermes.impl.owl/classify) reasoner cf-expression))
+
+(defn subsumes?
+  "Test subsumption between two CF expressions."
+  [reasoner cf-a cf-b]
+  ((dynaload 'com.eldrix.hermes.impl.owl/subsumes?) reasoner cf-a cf-b))
+
+(defn necessary-normal-form
+  "Compute the Necessary Normal Form of a CF expression."
+  [reasoner cf-expression]
+  ((dynaload 'com.eldrix.hermes.impl.owl/necessary-normal-form) reasoner cf-expression))

--- a/src/com/eldrix/hermes/impl/scg.clj
+++ b/src/com/eldrix/hermes/impl/scg.clj
@@ -9,9 +9,9 @@
 (ns ^:no-doc com.eldrix.hermes.impl.scg
   "Support for SNOMED CT compositional grammar.
   See http://snomed.org/scg"
-  (:require [clojure.edn :as edn]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
             [clojure.string :as str]
             [clojure.walk :as walk]
             [com.eldrix.hermes.impl.language :as lang]
@@ -58,7 +58,7 @@
    :escapedChar      (fn [_bs ch] (if (nil? ch) "\"" "\\"))
    :integerValue     (fn [& chars] (apply str chars))
    :decimalValue     (fn [& parts] (apply str parts))
-   :numericValue     (fn [& parts] (edn/read-string (apply str parts)))
+   :numericValue     (fn [& parts] (parse-double (apply str parts)))
    :true             (constantly true)
    :false            (constantly false)
    :booleanValue     identity
@@ -94,21 +94,6 @@
                            {:definitionStatus :equivalent-to :subExpression (first parts)}
                            {:definitionStatus (first parts) :subExpression (second parts)})))})
 
-(defn parse
-  "Parse a SNOMED-CT expression, as defined by the compositional grammar.
-  See https://confluence.ihtsdotools.org/display/DOCSCG/Compositional+Grammar+-+Specification+and+Guide
-
-  The result is a map with keys:
-  - :definitionStatus - :equivalent-to or :subtype-of
-  - :subExpression    - a map with:
-    - :focusConcepts  - vector of concept references [{:conceptId long, :term string?} ...]
-    - :refinements    - vector of refinement items, where each item is either:
-      - [name value] pair (ungrouped attribute, SNOMED group 0)
-      - #{[name value] ...} set (attribute group, SNOMED non-zero group)"
-  [s]
-  (->> (cg-parser s)
-       (insta/transform scg-transform)))
-
 ;;
 ;; Specs for the close-to-user (CTU) expression IR.
 ;; As this is based on the scg grammar, we use camelcase here.
@@ -131,16 +116,47 @@
 (s/def :ctu/definitionStatus #{:equivalent-to :subtype-of})
 (s/def :ctu/expression (s/keys :req-un [:ctu/definitionStatus :ctu/subExpression]))
 
+(s/fdef str->ctu
+  :args (s/cat :s string?)
+  :ret :ctu/expression)
+
+(defn str->ctu
+  "Parse a SNOMED-CT expression, as defined by the compositional grammar.
+  See https://confluence.ihtsdotools.org/display/DOCSCG/Compositional+Grammar+-+Specification+and+Guide
+
+  The result is a map with keys:
+  - :definitionStatus - :equivalent-to or :subtype-of
+  - :subExpression    - a map with:
+    - :focusConcepts  - vector of concept references [{:conceptId long, :term string?} ...]
+    - :refinements    - vector of refinement items, where each item is either:
+      - [name value] pair (ungrouped attribute, SNOMED group 0)
+      - #{[name value] ...} set (attribute group, SNOMED non-zero group)"
+  [s]
+  (let [p (cg-parser s)]
+    (if (insta/failure? p)
+      (let [fail (insta/get-failure p)]
+        (throw (ex-info (str "invalid SNOMED CT compositional grammar expression at line " (:line p) ", column " (:column p) ": '" (:text p) "'.") fail)))
+      (insta/transform scg-transform p))))
+
 ;;
 ;; Specs for the classifiable form (CF) IR.
 ;; Bare concept IDs (longs), sets throughout, no terms.
-;; Produced by `normalize`; suitable for comparison and subsumption testing.
+;; Produced by `ctu->cf+normalize`; suitable for comparison and subsumption testing.
 ;;
-(s/def :cf/attribute-value (s/or :concept    :info.snomed.Concept/id
-                                 :expression :cf/expression
-                                 :numeric    number?
-                                 :boolean    boolean?
-                                 :string     string?))
+(defmulti ^:private cf-attribute-value-type first)
+(defmethod cf-attribute-value-type :concept [_] (s/tuple #{:concept} :info.snomed.Concept/id))
+(defmethod cf-attribute-value-type :expression [_] (s/tuple #{:expression} :cf/expression))
+(defmethod cf-attribute-value-type :numeric [_] (s/tuple #{:numeric} number?))
+(defmethod cf-attribute-value-type :boolean [_] (s/tuple #{:boolean} boolean?))
+(defmethod cf-attribute-value-type :string [_] (s/tuple #{:string} string?))
+(s/def :cf/attribute-value
+  (s/with-gen
+    (s/multi-spec cf-attribute-value-type first)
+    #(gen/one-of [(gen/fmap (fn [id] [:concept id]) (s/gen :info.snomed.Concept/id))
+                  (gen/fmap (fn [n] [:numeric (long n)]) (gen/choose 0 1000))
+                  (gen/fmap (fn [n] [:numeric (/ (double n) 100.0)]) (gen/choose 0 100000))
+                  (gen/fmap (fn [s] [:string s]) (gen/string-alphanumeric))
+                  (gen/fmap (fn [b] [:boolean b]) (gen/boolean))])))
 (s/def :cf/attribute (s/tuple :info.snomed.Concept/id :cf/attribute-value))
 (s/def :cf/focus-concepts (s/coll-of :info.snomed.Concept/id :kind set? :min-count 1))
 (s/def :cf/ungrouped (s/coll-of :cf/attribute :kind set?))
@@ -210,12 +226,12 @@
   (let [stripped (strip-terms expression)]
     (assoc stripped :subExpression (canonicalize-subexpression (:subExpression stripped)))))
 
-(s/fdef concept->expression*
+(s/fdef concept->ctu*
   :args (s/cat :concept-id :info.snomed.Concept/id
                :defined? boolean?
                :properties map?))
 
-(defn concept->expression*
+(defn concept->ctu*
   "Build an SCG expression IR from a concept's properties-by-group data.
   Parameters:
   - concept-id  : the SNOMED CT concept identifier
@@ -297,12 +313,12 @@
         refinements (:refinements subexp)]
     (if refinements (str focus-concepts ":" (render-refinements config refinements)) focus-concepts)))
 
-(s/fdef render
+(s/fdef ctu->str
   :args (s/cat :store (s/? any?)
                :expression :ctu/expression
                :opts (s/? (s/keys :opt-un [::update-terms? ::accept-language ::hide-terms?]))))
 
-(defn render
+(defn ctu->str
   "Render an expression into string form.
   Single-arity renders using terms already present in the expression.
   Three-arity takes a store, expression, and options map:
@@ -313,7 +329,7 @@
    (str ({:equivalent-to "===" :subtype-of "<<<"} (:definitionStatus expression))
         " " (render-subexpression {} (:subExpression expression))))
   ([store expression]
-   (render store expression {:update-terms? false}))
+   (ctu->str store expression {:update-terms? false}))
   ([store expression {:keys [update-terms? accept-language] :as opts}]
    (let [lang-refsets (lang/match store accept-language)
          cfg (if (and update-terms? (seq lang-refsets))
@@ -323,11 +339,11 @@
           " " (render-subexpression cfg (:subExpression expression))))))
 
 
-(s/fdef concept->expression
+(s/fdef concept->ctu
   :args (s/cat :store any?
                :concept-id :info.snomed.Concept/id))
 
-(defn concept->expression
+(defn concept->ctu
   "Return the definition of a concept as an SCG expression IR.
   For a primitive concept, the concept itself is the sole focus concept with
   definition status :subtype-of. For a fully-defined concept, the IS-A parents become
@@ -336,22 +352,23 @@
   Returns nil if the concept does not exist."
   [store concept-id]
   (when-let [c (store/concept store concept-id)]
-    (concept->expression* concept-id (snomed/defined? c) (store/properties-by-group store concept-id))))
+    (concept->ctu* concept-id (snomed/defined? c) (store/properties-by-group store concept-id))))
 
-(defn- properties->attributes
-  "Extract non-IS-A attributes from properties-by-group as ungrouped + groups."
+(defn properties->attributes
+  "Extract non-IS-A attributes from properties-by-group as ungrouped + groups.
+  Values from the store are always concept references."
   [props]
   (let [group-0 (get props 0)
         ungrouped (->> (dissoc group-0 snomed/IsA)
                        (mapcat (fn [[tid targets]]
-                                 (map #(vector tid %) targets)))
+                                 (map #(vector tid [:concept %]) targets)))
                        set)
         groups (->> (dissoc props 0)
                     (vals)
                     (into #{}
                           (map (fn [attrs]
                                  (set (mapcat (fn [[tid targets]]
-                                               (map #(vector tid %) targets))
+                                               (map #(vector tid [:concept %]) targets))
                                              attrs))))))]
     {:ungrouped ungrouped :groups groups}))
 
@@ -381,19 +398,19 @@
          :groups (into groups (mapcat :groups parent-results))}))))
 
 (defn- concept-valued?
-  "True if an attribute's value is a concept ID."
-  [[_ v]]
-  (integer? v))
+  "True if an attribute's value is a concept reference."
+  [[_ [tag]]]
+  (= :concept tag))
 
 (defn- leaf-values-for-type
   "Given attributes sharing the same type, keep only those with the most
   specific (leaf) values — i.e., remove values subsumed by another."
   [store attrs]
-  (let [value-ids (map second attrs)
+  (let [value-ids (map (fn [[_ [_ v]]] v) attrs)
         leaf-ids (store/leaves store value-ids)]
-    (filterv #(contains? leaf-ids (second %)) attrs)))
+    (filterv (fn [[_ [_ v]]] (contains? leaf-ids v)) attrs)))
 
-(defn- remove-subsumed-attributes
+(defn remove-subsumed-attributes
   "Remove attributes whose value is subsumed by another with the same type.
   For each attribute type, keeps only the most specific (leaf) values."
   [store attrs]
@@ -404,11 +421,16 @@
          (into (set other) (mapcat #(leaf-values-for-type store %))))))
 
 (defn- attribute-subsumes?
-  "True if attribute a1 subsumes a2: a2's type is-a a1's type and a2's value is-a a1's value."
-  [store [tid1 vid1] [tid2 vid2]]
-  (and (integer? vid1) (integer? vid2)
-       (or (= tid2 tid1) (store/is-a? store tid2 tid1))
-       (or (= vid2 vid1) (store/is-a? store vid2 vid1))))
+  "True if attribute a1 subsumes a2: a2's type is-a a1's type and a2's value
+  is subsumed by a1's value. Concept values use is-a subsumption; concrete
+  values (numeric, string, boolean) require exact match."
+  [store [tid1 [tag1 vid1]] [tid2 [tag2 vid2]]]
+  (and (or (= tid2 tid1) (store/is-a? store tid2 tid1))
+       (cond
+         (and (= :concept tag1) (= :concept tag2))
+         (or (= vid2 vid1) (store/is-a? store vid2 vid1))
+         (= tag1 tag2) (= vid1 vid2)
+         :else false)))
 
 (defn- group-subsumes?
   "True if group g1 subsumes g2: every attribute in g1 has a more specific
@@ -416,24 +438,98 @@
   [store g1 g2]
   (every? (fn [a1] (some #(attribute-subsumes? store a1 %) g2)) g1))
 
-(defn- remove-subsumed-groups
+(defn remove-subsumed-groups
   "Remove groups that are subsumed by a different, more specific group."
   [store groups]
   (into #{} (remove (fn [g] (some #(and (not= g %) (group-subsumes? store g %)) groups)) groups)))
 
 (defn- ctu-attr->cf-attr
-  "Convert a CTU attribute [concept-ref value] to a CF attribute [type-id value]."
+  "Convert a CTU attribute [concept-ref value] to a CF attribute [type-id tagged-value].
+  Values are tagged: [:concept id], [:expression expr], [:numeric n],
+  [:string s], [:boolean b]."
   [[attr-name attr-value]]
   [(:conceptId attr-name)
    (cond
-     (and (map? attr-value) (:conceptId attr-value)) (:conceptId attr-value)
-     (and (map? attr-value) (:focusConcepts attr-value)) attr-value ;; nested subExpression, normalized later
-     :else attr-value)])
+     (and (map? attr-value) (:conceptId attr-value)) [:concept (:conceptId attr-value)]
+     (and (map? attr-value) (:focusConcepts attr-value)) [:expression attr-value] ;; nested subExpression, normalized later
+     (number? attr-value)  [:numeric attr-value]
+     (string? attr-value)  [:string attr-value]
+     (boolean? attr-value) [:boolean attr-value]
+     :else (throw (ex-info "Unsupported CTU attribute value" {:value attr-value})))])
 
-(s/fdef normalize
+(s/fdef ctu->cf
+  :args (s/cat :expression :ctu/expression)
+  :ret :cf/expression)
+
+(defn ctu->cf
+  "Convert a close-to-user expression to classifiable form without expansion.
+  Preserves original focus concept IDs and definition status, only transforming
+  the data shape: CTU concept maps become bare IDs, attribute values become
+  tagged pairs. Suitable for OWL classification where the reasoner handles
+  expansion via the loaded ontology.
+
+  Contrast with [[ctu->cf+normalize]], which expands fully-defined focus concepts to
+  proximal primitive supertypes and merges defining attributes — appropriate for
+  structural subsumption testing but lossy for OWL reasoning."
+  [expression]
+  (let [{:keys [focusConcepts refinements]} (:subExpression expression)
+        focus-ids (into #{} (map :conceptId) focusConcepts)
+        ungrouped (->> (filterv vector? (or refinements []))
+                       (map ctu-attr->cf-attr)
+                       set)
+        groups (->> (filterv set? (or refinements []))
+                    (into #{} (map (fn [g] (set (map ctu-attr->cf-attr g))))))
+        norm-val (fn [[tag v :as tagged]]
+                   (if (= :expression tag)
+                     [:expression (ctu->cf {:definitionStatus :equivalent-to :subExpression v})]
+                     tagged))
+        norm-attr (fn [[t v]] [t (norm-val v)])
+        ungrouped (set (map norm-attr ungrouped))
+        groups (into #{} (map (fn [g] (set (map norm-attr g)))) groups)]
+    (cond-> {:cf/definition-status (:definitionStatus expression)
+             :cf/focus-concepts    focus-ids}
+      (seq ungrouped) (assoc :cf/ungrouped ungrouped)
+      (seq groups) (assoc :cf/groups groups))))
+
+(defn- validate-concept
+  [store {:keys [conceptId]} role]
+  (when-not (store/concept store conceptId)
+    (throw (ex-info (str "Concept not found: " conceptId) {:type :concept-not-found :conceptId conceptId :role role}))))
+
+(declare validate-subexpression)
+
+(defn- validate-refinements
+  [store refinements]
+  (doseq [r refinements]
+    (let [attrs (if (set? r) r [r])]
+      (doseq [[attr-name attr-value] attrs]
+        (validate-concept store attr-name :attribute-type)
+        (cond
+          (and (map? attr-value) (:focusConcepts attr-value))
+          (validate-subexpression store attr-value)
+          (and (map? attr-value) (:conceptId attr-value))
+          (validate-concept store attr-value :attribute-value))))))
+
+(defn- validate-concepts
+  [store concepts role]
+  (doseq [c concepts]
+    (validate-concept store c role)))
+
+(defn- validate-subexpression
+  [store {:keys [focusConcepts refinements]}]
+  (validate-concepts store focusConcepts :focus-concept)
+  (when refinements
+    (validate-refinements store refinements)))
+
+(defn validate
+  "Validate an expression, throwing on first invalid concept reference."
+  [store expression]
+  (validate-subexpression store (:subExpression expression)))
+
+(s/fdef ctu->cf+normalize
   :args (s/cat :store any? :expression :ctu/expression))
 
-(defn normalize
+(defn ctu->cf+normalize
   "Transform a close-to-user expression to classifiable form.
   Expands fully-defined focus concepts to proximal primitive supertypes,
   merges defining attributes with user refinements, removes redundancy.
@@ -441,8 +537,10 @@
     :cf/definition-status  - always :subtype-of
     :cf/focus-concepts     - set of proximal primitive concept IDs
     :cf/ungrouped         - set of [type-id value] attribute pairs
-    :cf/groups            - set of #{[type-id value] ...} attribute groups"
+    :cf/groups            - set of #{[type-id value] ...} attribute groups
+  Throws if any referenced concepts are not found in the store."
   [store expression]
+  (validate store expression)
   (let [{:keys [focusConcepts refinements]} (:subExpression expression)
         user-ungrouped (->> (filterv vector? (or refinements []))
                             (map ctu-attr->cf-attr)
@@ -453,10 +551,10 @@
         all-primitives (into #{} (mapcat :primitives) expansions)
         all-ungrouped (into (into #{} (mapcat :ungrouped) expansions) user-ungrouped)
         all-groups (into (into #{} (mapcat :groups) expansions) user-groups)
-        norm-val (fn [v]
-                   (if (and (map? v) (:focusConcepts v))
-                     (normalize store {:definitionStatus :equivalent-to :subExpression v})
-                     v))
+        norm-val (fn [[tag v :as tagged]]
+                   (if (= :expression tag)
+                     [:expression (ctu->cf+normalize store {:definitionStatus :equivalent-to :subExpression v})]
+                     tagged))
         norm-attr (fn [[t v]] [t (norm-val v)])
         all-ungrouped (set (map norm-attr all-ungrouped))
         all-groups (into #{} (map (fn [g] (set (map norm-attr g)))) all-groups)
@@ -468,20 +566,21 @@
       (seq all-ungrouped) (assoc :cf/ungrouped all-ungrouped)
       (seq all-groups) (assoc :cf/groups all-groups))))
 
-(declare classifiable->ctu)
+(declare cf->ctu)
 
 (defn- cf-value->ctu-value
-  "Convert a classifiable form attribute value to a CTU attribute value."
-  [v]
-  (cond
-    (integer? v) {:conceptId v}
-    (and (map? v) (contains? v :cf/focus-concepts)) (:subExpression (classifiable->ctu v))
-    :else v))
+  "Convert a classifiable form tagged attribute value to a CTU attribute value."
+  [[tag v]]
+  (case tag
+    :concept         {:conceptId v}
+    :expression      (:subExpression (cf->ctu v))
+    (:numeric :string :boolean) v
+    (throw (ex-info "Unknown CF attribute value tag" {:tag tag :value v}))))
 
-(s/fdef classifiable->ctu
+(s/fdef cf->ctu
   :args (s/cat :normal-form :cf/expression))
 
-(defn classifiable->ctu
+(defn cf->ctu
   "Convert a classifiable form expression to a close-to-user expression IR
   suitable for rendering."
   [{:cf/keys [definition-status focus-concepts ungrouped groups]}]
@@ -502,96 +601,52 @@
                       (seq refinements)
                       (assoc :refinements refinements))}))
 
+(s/fdef cf-subsumes?
+  :args (s/cat :store any? :a :cf/expression :b :cf/expression))
+
+(defn cf-subsumes?
+  "Does classifiable form expression a subsume b?
+  Operates on pre-normalized CF expressions:
+    1. Both expressions must have non-empty focus concepts
+    2. Every focus concept in A must subsume at least one in B — O(F_a × F_b)
+    3. Every ungrouped attribute in A must be subsumed by one in B — O(U_a × U_b)
+    4. Every group in A must match a group in B — O(G_a × G_b × K²)
+  where F=focus concepts, U=ungrouped attrs, G=groups, K=attrs per group.
+  All counts are small (single digits), so effectively constant.
+  is-a? is O(1) via precomputed transitive closure."
+  [store a b]
+  (boolean
+    (let [focus-a (:cf/focus-concepts a)
+          focus-b (:cf/focus-concepts b)]
+      (and (seq focus-a)
+           (seq focus-b)
+           (every? (fn [fa]
+                     (some (fn [fb] (or (= fb fa) (store/is-a? store fb fa)))
+                           focus-b))
+                   focus-a)
+           (every? (fn [ua]
+                     (some #(attribute-subsumes? store ua %) (:cf/ungrouped b)))
+                   (:cf/ungrouped a))
+           (every? (fn [ga]
+                     (some #(group-subsumes? store ga %) (:cf/groups b)))
+                   (:cf/groups a))))))
+
 (s/fdef subsumes?
   :args (s/cat :store any? :a :ctu/expression :b :ctu/expression))
 
 (defn subsumes?
   "Does expression a subsume expression b?
-  Both expressions are normalized to classifiable form, then compared:
-    1. Every focus concept in A must subsume at least one in B — O(F_a × F_b)
-    2. Every ungrouped attribute in A must be subsumed by one in B — O(U_a × U_b)
-    3. Every group in A must match a group in B — O(G_a × G_b × K²)
-  where F=focus concepts, U=ungrouped attrs, G=groups, K=attrs per group.
-  All counts are small (single digits), so effectively constant.
-  is-a? is O(1) via precomputed transitive closure.
-
-  Note: normalizes both expressions on every call. For repeated subsumption
-  checks against the same expression, consider a variant that accepts
-  pre-normalized CF expressions or returns a closure from a single expression."
+  Normalizes both expressions to classifiable form and compares.
+  See [[cf-subsumes?]] for use with pre-normalized expressions."
   [store a b]
-  (let [a' (normalize store a)
-        b' (normalize store b)
-        ;; 1. Focus concept check: every focus in A subsumes at least one in B
-        focus-ok? (every? (fn [fa]
-                            (some (fn [fb] (or (= fb fa) (store/is-a? store fb fa)))
-                                  (:cf/focus-concepts b')))
-                          (:cf/focus-concepts a'))
-        ;; 2. Ungrouped attribute check
-        ungrouped-ok? (every? (fn [ua]
-                                (some #(attribute-subsumes? store ua %) (:cf/ungrouped b')))
-                              (:cf/ungrouped a'))
-        ;; 3. Group check: every group in A has a matching group in B
-        groups-ok? (every? (fn [ga]
-                             (some #(group-subsumes? store ga %) (:cf/groups b')))
-                           (:cf/groups a'))]
-    (and focus-ok? ungrouped-ok? groups-ok?)))
+  (cf-subsumes? store (ctu->cf+normalize store a) (ctu->cf+normalize store b)))
 
-(defn- validate-concept-reference
-  "Validate a concept reference exists. Returns error map or nil."
-  [store {:keys [conceptId]} role]
-  (when-not (store/concept store conceptId)
-    {:type :concept-not-found :conceptId conceptId :role role}))
-
-(declare validate-subexpression)
-
-(defn- validate-attribute-value
-  "Validate an attribute value, recursing into nested sub-expressions."
-  [store value]
-  (cond
-    (and (map? value) (:focusConcepts value))
-    (validate-subexpression store value)
-
-    (and (map? value) (:conceptId value))
-    (when-let [err (validate-concept-reference store value :attribute-value)]
-      [err])
-
-    :else nil))
-
-(defn- validate-attribute
-  "Validate a single attribute: type and value concepts exist and are active."
-  [store [attr-name attr-value]]
-  (let [type-err (validate-concept-reference store attr-name :attribute-type)
-        val-errs (validate-attribute-value store attr-value)]
-    (cond-> []
-      type-err (conj type-err)
-      val-errs (into val-errs))))
-
-(defn- validate-subexpression
-  "Validate a sub-expression: focus concepts and refinements."
-  [store {:keys [focusConcepts refinements]}]
-  (let [focus-errs (keep #(validate-concept-reference store % :focus-concept) focusConcepts)
-        attr-errs (when refinements
-                    (mapcat (fn [r]
-                              (if (set? r)
-                                (mapcat #(validate-attribute store %) r)
-                                (validate-attribute store r)))
-                            refinements))]
-    (into (vec focus-errs) attr-errs)))
-
-(s/fdef errors
-  :args (s/cat :store any? :expression :ctu/expression))
-
-(defn errors
-  "Return a sequence of error maps for an expression, or nil if valid.
-  Checks that all referenced concepts exist and are active."
-  [store expression]
-  (seq (validate-subexpression store (:subExpression expression))))
 
 (comment
   (def st (store/open-store "snomed.db/store.db"))
-  (concept->expression st 24700007)
-  (normalize st (parse "24700007"))
-  (normalize st (parse "80146002"))
-  (errors st (parse "24700007"))
-  (errors st (parse "100000102"))
+  (concept->ctu st 24700007)
+  (ctu->cf+normalize st (str->ctu "24700007"))
+  (ctu->cf+normalize st (str->ctu "80146002"))
+  (validate st (str->ctu "24700007"))
+  (validate st (str->ctu "100000102"))
   )

--- a/src/com/eldrix/hermes/impl/scg.clj
+++ b/src/com/eldrix/hermes/impl/scg.clj
@@ -506,40 +506,37 @@
       (seq ungrouped) (assoc :cf/ungrouped ungrouped)
       (seq groups) (assoc :cf/groups groups))))
 
-(defn- validate-concept
-  [store {:keys [conceptId]} role]
-  (when-not (store/concept store conceptId)
-    (throw (ex-info (str "Concept not found: " conceptId) {:type :concept-not-found :conceptId conceptId :role role}))))
+(declare valid-subexpression?)
 
-(declare validate-subexpression)
+(defn- valid-concept?
+  [store {:keys [conceptId]}]
+  (some? (store/concept store conceptId)))
 
-(defn- validate-refinements
+(defn- valid-refinements?
   [store refinements]
-  (doseq [r refinements]
-    (let [attrs (if (set? r) r [r])]
-      (doseq [[attr-name attr-value] attrs]
-        (validate-concept store attr-name :attribute-type)
-        (cond
-          (and (map? attr-value) (:focusConcepts attr-value))
-          (validate-subexpression store attr-value)
-          (and (map? attr-value) (:conceptId attr-value))
-          (validate-concept store attr-value :attribute-value))))))
+  (every? (fn [r]
+            (let [attrs (if (set? r) r [r])]
+              (every? (fn [[attr-name attr-value]]
+                        (and (valid-concept? store attr-name)
+                             (cond
+                               (and (map? attr-value) (:focusConcepts attr-value))
+                               (valid-subexpression? store attr-value)
+                               (and (map? attr-value) (:conceptId attr-value))
+                               (valid-concept? store attr-value)
+                               :else true)))
+                      attrs)))
+          refinements))
 
-(defn- validate-concepts
-  [store concepts role]
-  (doseq [c concepts]
-    (validate-concept store c role)))
-
-(defn- validate-subexpression
+(defn- valid-subexpression?
   [store {:keys [focusConcepts refinements]}]
-  (validate-concepts store focusConcepts :focus-concept)
-  (when refinements
-    (validate-refinements store refinements)))
+  (and (every? #(valid-concept? store %) focusConcepts)
+       (or (nil? refinements)
+           (valid-refinements? store refinements))))
 
-(defn validate
-  "Validate an expression, throwing on first invalid concept reference."
+(defn valid?
+  "Returns true if all concept references in an expression exist in the store."
   [store expression]
-  (validate-subexpression store (:subExpression expression)))
+  (valid-subexpression? store (:subExpression expression)))
 
 (s/fdef ctu->cf+normalize
   :args (s/cat :store any? :expression :ctu/expression))
@@ -555,7 +552,8 @@
     :cf/groups            - set of #{[type-id value] ...} attribute groups
   Throws if any referenced concepts are not found in the store."
   [store expression]
-  (validate store expression)
+  (when-not (valid? store expression)
+    (throw (ex-info "Expression contains invalid concept references" {:expression expression})))
   (let [{:keys [focusConcepts refinements]} (:subExpression expression)
         user-ungrouped (->> (filterv vector? (or refinements []))
                             (map ctu-attr->cf-attr)
@@ -662,6 +660,6 @@
   (concept->ctu st 24700007)
   (ctu->cf+normalize st (str->ctu "24700007"))
   (ctu->cf+normalize st (str->ctu "80146002"))
-  (validate st (str->ctu "24700007"))
-  (validate st (str->ctu "100000102"))
+  (valid? st (str->ctu "24700007"))
+  (valid? st (str->ctu "100000102"))
   )

--- a/src/com/eldrix/hermes/impl/scg.clj
+++ b/src/com/eldrix/hermes/impl/scg.clj
@@ -538,6 +538,65 @@
   [store expression]
   (valid-subexpression? store (:subExpression expression)))
 
+(defn- replace-concept
+  "Replace an inactive concept with its historical target, if available.
+  Returns the concept unchanged if active, or if no single replacement exists.
+  `refset-ids` is a set of historical association refset identifiers to use."
+  [store refset-ids {:keys [conceptId] :as concept}]
+  (let [c (store/concept store conceptId)]
+    (if (or (nil? c) (:active c))
+      concept
+      (let [items (->> (store/component-refset-items store conceptId)
+                       (filter #(and (:active %) (refset-ids (:refsetId %)))))]
+        (if (= 1 (count items))
+          (let [target-id (:targetComponentId (first items))
+                target (store/concept store target-id)]
+            (if (and target (:active target))
+              {:conceptId target-id}
+              concept))
+          concept)))))
+
+(declare replace-subexpression)
+
+(defn- replace-refinement-value
+  [store refset-ids v]
+  (cond
+    (and (map? v) (:focusConcepts v)) (replace-subexpression store refset-ids v)
+    (and (map? v) (:conceptId v))     (replace-concept store refset-ids v)
+    :else                              v))
+
+(defn- replace-refinements
+  [store refset-ids refinements]
+  (mapv (fn [r]
+          (if (set? r)
+            (set (map (fn [[attr-name attr-value]]
+                        [(replace-concept store refset-ids attr-name)
+                         (replace-refinement-value store refset-ids attr-value)])
+                      r))
+            [(replace-concept store refset-ids (first r))
+             (replace-refinement-value store refset-ids (second r))]))
+        refinements))
+
+(defn- replace-subexpression
+  [store refset-ids {:keys [focusConcepts refinements] :as subexpr}]
+  (cond-> (assoc subexpr :focusConcepts (mapv #(replace-concept store refset-ids %) focusConcepts))
+    refinements (assoc :refinements (replace-refinements store refset-ids refinements))))
+
+(s/fdef replace-historical
+  :args (s/cat :store any? :expression :ctu/expression
+               :kwargs (s/keys* :opt-un [::profile]))
+  :ret :ctu/expression)
+(defn replace-historical
+  "Replace inactive concept references in an expression with their historical
+  targets. By default, uses :HISTORY-MIN (SAME_AS only) which is the only
+  lossless replacement. Replacement occurs only when a single active target
+  exists for the given history profile.
+  Options:
+    :profile - :HISTORY-MIN (default), :HISTORY-MOD or :HISTORY-MAX"
+  [store expression & {:keys [profile] :or {profile :HISTORY-MIN}}]
+  (let [refset-ids (set (store/history-profile store profile))]
+    (update expression :subExpression #(replace-subexpression store refset-ids %))))
+
 (s/fdef ctu->cf+normalize
   :args (s/cat :store any? :expression :ctu/expression))
 
@@ -662,4 +721,6 @@
   (ctu->cf+normalize st (str->ctu "80146002"))
   (valid? st (str->ctu "24700007"))
   (valid? st (str->ctu "100000102"))
+  (replace-historical st (str->ctu "100000102"))
+  (replace-historical st (str->ctu "100000102") :profile :HISTORY-MOD)
   )

--- a/src/com/eldrix/hermes/impl/scg.clj
+++ b/src/com/eldrix/hermes/impl/scg.clj
@@ -149,14 +149,29 @@
 (defmethod cf-attribute-value-type :numeric [_] (s/tuple #{:numeric} number?))
 (defmethod cf-attribute-value-type :boolean [_] (s/tuple #{:boolean} boolean?))
 (defmethod cf-attribute-value-type :string [_] (s/tuple #{:string} string?))
+(defn- gen-leaf-attribute-value
+  "Generator for non-recursive CF attribute values."
+  []
+  (gen/one-of [(gen/fmap (fn [id] [:concept id]) (s/gen :info.snomed.Concept/id))
+               (gen/fmap (fn [n] [:numeric (long n)]) (gen/choose 0 1000))
+               (gen/fmap (fn [n] [:numeric (/ (double n) 100.0)]) (gen/choose 0 100000))
+               (gen/fmap (fn [s] [:string s]) (gen/string-alphanumeric))
+               (gen/fmap (fn [b] [:boolean b]) (gen/boolean))]))
+
+(defn- gen-nested-expression
+  "Generator for a simple nested CF expression (single focus concept, no further nesting)."
+  []
+  (gen/fmap (fn [[fc ds]]
+              [:expression {:cf/focus-concepts #{fc}
+                            :cf/definition-status ds}])
+            (gen/tuple (s/gen :info.snomed.Concept/id)
+                       (gen/elements [:subtype-of :equivalent-to]))))
+
 (s/def :cf/attribute-value
   (s/with-gen
     (s/multi-spec cf-attribute-value-type first)
-    #(gen/one-of [(gen/fmap (fn [id] [:concept id]) (s/gen :info.snomed.Concept/id))
-                  (gen/fmap (fn [n] [:numeric (long n)]) (gen/choose 0 1000))
-                  (gen/fmap (fn [n] [:numeric (/ (double n) 100.0)]) (gen/choose 0 100000))
-                  (gen/fmap (fn [s] [:string s]) (gen/string-alphanumeric))
-                  (gen/fmap (fn [b] [:boolean b]) (gen/boolean))])))
+    #(gen/frequency [[8 (gen-leaf-attribute-value)]
+                     [2 (gen-nested-expression)]])))
 (s/def :cf/attribute (s/tuple :info.snomed.Concept/id :cf/attribute-value))
 (s/def :cf/focus-concepts (s/coll-of :info.snomed.Concept/id :kind set? :min-count 1))
 (s/def :cf/ungrouped (s/coll-of :cf/attribute :kind set?))

--- a/src/com/eldrix/hermes/importer.clj
+++ b/src/com/eldrix/hermes/importer.clj
@@ -46,6 +46,12 @@
        (filter #(= (:release-type %) "Snapshot"))
        (filter :parser)))
 
+(def default-exclude
+  "Default set of identifiers to exclude from import.
+  OWL expression reference set files are large and only needed for OWL
+  reasoning support, so are excluded by default."
+  #{:info.snomed/OWLExpressionRefset})
+
 (def ^:private metadata-parsers
   {:effectiveTime snomed/parse-date
    :deltaToDate   snomed/parse-date
@@ -105,36 +111,45 @@
 
 (defn process-file
   "Process the specified file, streaming batched results to the channel
-  specified, blocking if channel not being drained. 
+  specified, blocking if channel not being drained.
   Parameters:
-  - f     : anything coercible using clojure.java.io/reader
+  - f       : anything coercible using clojure.java.io/reader
+  - out-c   : output channel
+  - options :
+    - :batch-size : number of rows per batch (default 1000)
+    - :include    : predicate on identifier; only matching files processed
+    - :exclude    : predicate on identifier; matching files skipped
 
   Each batch is a map with keys
    - :type      : a type of SNOMED component
    - :parser    : a parser that can take each row and give you data
    - :headings  : a sequence of headings from the original file
    - :data      : a sequence of vectors representing each column."
-  [f out-c & {:keys [batch-size] :or {batch-size 1000}}]
-  (let [{:keys [identifier parser filename component]} (parse-filename f)]
+  [f out-c & {:keys [batch-size include exclude]
+              :or   {batch-size 1000 include (constantly true) exclude default-exclude}}]
+  (let [{:keys [identifier parser filename component]} (parse-filename f)
+        exclude (or exclude #{})]
     (when parser
-      (with-open [reader (io/reader f)]
-        (let [csv-data (csv/read-csv reader :separator \tab :quote \u0000)
-              headings (first csv-data)
-              data (rest csv-data)
-              batches (->> data
-                           (partition-all batch-size)
-                           (map #(hash-map :file f
-                                           :type identifier
-                                           :parser parser
-                                           :headings headings
-                                           :data %)))]
-          (log/info "Processing: " filename " type: " component)
-          (log/debug "Processing " (count batches) " batches")
-          (doseq [batch batches]
-            (log/debug "Processing batch " {:batch (dissoc batch :data) :first-data (-> batch :data first)})
-            (when-not (a/>!! out-c batch)
-              (log/debug "Processing cancelled (output channel closed)")
-              (throw (InterruptedException. "process cancelled")))))))))
+      (if (and (include identifier) (not (exclude identifier)))
+        (with-open [reader (io/reader f)]
+          (let [csv-data (csv/read-csv reader :separator \tab :quote \u0000)
+                headings (first csv-data)
+                data (rest csv-data)
+                batches (->> data
+                             (partition-all batch-size)
+                             (map #(hash-map :file f
+                                             :type identifier
+                                             :parser parser
+                                             :headings headings
+                                             :data %)))]
+            (log/info "Processing: " filename " type: " component)
+            (log/debug "Processing " (count batches) " batches")
+            (doseq [batch batches]
+              (log/debug "Processing batch " {:batch (dissoc batch :data) :first-data (-> batch :data first)})
+              (when-not (a/>!! out-c batch)
+                (log/debug "Processing cancelled (output channel closed)")
+                (throw (InterruptedException. "process cancelled"))))))
+        (log/info "Skipping: " filename " type: " component)))))
 
 (defn import-file
   "Import a SNOMED file, returning a map containing :type :headings :parser 
@@ -149,20 +164,21 @@
 
 (s/fdef load-snomed-files
   :args (s/cat :files (s/coll-of :info.snomed/ReleaseFile)
-               :opts (s/keys* :opt-un [::nthreads ::batch-size])))
+               :opts (s/keys* :opt-un [::nthreads ::batch-size ::include ::exclude])))
 
 (defn load-snomed-files
   "Imports a SNOMED-CT distribution from the specified files, returning
   results on the returned channel which will be closed once all files have been
-  sent through. Any exceptions will be passed on the channel."
-  [files & {:keys [nthreads batch-size] :or {nthreads 4 batch-size 5000}}]
+  sent through. Any exceptions will be passed on the channel.
+  Options are passed through to [[process-file]]."
+  [files & {:keys [nthreads] :or {nthreads 4} :as opts}]
   (let [raw-c (a/chan)                                  ;; CSV data in batches with :type, :headings and :data, :data as a vector of raw strings
         processed-c (a/chan)]                           ;; CSV data in batches with :type, :headings and :data, :data as a vector of SNOMED entities
     (a/thread
       (log/debug "Processing " (count files) " files")
       (try
         (doseq [file files]
-          (process-file (:path file) raw-c :batch-size batch-size))
+          (process-file (:path file) raw-c opts))
         (catch Throwable e
           (log/debug "Error during raw SNOMED file import: " e)
           (a/>!! processed-c e)))

--- a/src/com/eldrix/hermes/snomed.clj
+++ b/src/com/eldrix/hermes/snomed.clj
@@ -796,7 +796,7 @@
    :info.snomed/ComplexMapRefset           parse-complex-map-refset-item
    :info.snomed/ExtendedMapRefset          parse-extended-map-refset-item
    :info.snomed/AttributeValueRefset       parse-attribute-value-refset-item
-   ;:info.snomed/OWLExpressionRefset    parse-owl-expression-refset-item})
+   :info.snomed/OWLExpressionRefset        parse-owl-expression-refset-item
    :info.snomed/ModuleDependencyRefset     parse-module-dependency-refset-item
    :info.snomed/MRCMDomainRefset           parse-mrcm-domain-refset-item
    :info.snomed/MRCMAttributeDomainRefset  parse-mrcm-attribute-domain-refset-item
@@ -1136,6 +1136,11 @@
 ;; SNOMED CT 'model' component and reference set
 (def ModelModule 900000000000012004)
 (def ModuleDependencyReferenceSet 900000000000534007)
+
+;; OWL expression reference sets
+(def RoleGroup 609096000)
+(def OWLAxiomReferenceSet 733073007)
+(def OWLOntologyReferenceSet 762103008)
 
 ;; SNOMED CT Machine Readable Concept Model (MRCM)
 (def MRCMDomainReferenceSet 723589008)

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -13,6 +13,7 @@
     </root>
 
     <logger name="com.eldrix" level="warn"/>
+    <logger name="org.semanticweb.elk.reasoner.completeness" level="error"/>
     <logger name="org.eclipse.jetty.server.Server" level="info"/>
 
 </configuration>

--- a/test/src/com/eldrix/hermes/core_test.clj
+++ b/test/src/com/eldrix/hermes/core_test.clj
@@ -3,7 +3,8 @@
             [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha :as stest]
             [clojure.test :refer [deftest testing is use-fixtures]]
-            [com.eldrix.hermes.core :as hermes]))
+            [com.eldrix.hermes.core :as hermes]
+            [com.eldrix.hermes.impl.reasoner :as reasoner]))
 
 (stest/instrument)
 
@@ -164,4 +165,33 @@
 #_(deftest ^:live test-historical-assumptions
     (let [counts (#'hermes/historical-association-counts *svc*)]
       (is (= 1 (get counts snomed/ReplacedByReferenceSet)))))
+
+(deftest ^:live test-subsumes-concept-ids
+  (testing "concept id fast path"
+    (is (= :equivalent (hermes/subsumes *svc* 24700007 24700007))
+        "A concept is equivalent to itself")
+    (is (= :subsumes (hermes/subsumes *svc* 6118003 24700007))
+        "Disease of CNS subsumes Multiple sclerosis")
+    (is (= :subsumed-by (hermes/subsumes *svc* 24700007 6118003))
+        "Multiple sclerosis is subsumed by Disease of CNS")
+    (is (= :not-subsumed (hermes/subsumes *svc* 24700007 73211009))
+        "Multiple sclerosis and Diabetes mellitus are unrelated")))
+
+(deftest ^:live test-subsumes-strings
+  (testing "string expressions"
+    (is (= :equivalent (hermes/subsumes *svc* "24700007" "24700007"))
+        "Same concept as string")
+    (is (= :subsumes (hermes/subsumes *svc* "6118003" "24700007"))
+        "Parent subsumes child as strings")))
+
+(deftest ^:live test-subsumes-mixed-input
+  (testing "concept id and string"
+    (is (= :subsumes (hermes/subsumes *svc* "6118003" 24700007))
+        "String and concept id can be mixed")))
+
+(deftest ^:live test-subsumes-owl-unavailable
+  (when-not @reasoner/owl-loaded?
+    (testing "throws when OWL mode requested but libraries unavailable"
+      (is (thrown? clojure.lang.ExceptionInfo
+                  (hermes/subsumes *svc* 24700007 24700007 :mode :owl))))))
 

--- a/test/src/com/eldrix/hermes/importer_test.clj
+++ b/test/src/com/eldrix/hermes/importer_test.clj
@@ -49,5 +49,13 @@
             "1434181000001106" "ABC01256Q" ""] (first data))
         "Empty last column should be returned as empty string")))
 
+(deftest process-file-exclude-nil
+  (testing "passing :exclude nil should not throw NPE"
+    (let [f   (io/resource "example-snapshot/Terminology/sct2_Concept_Snapshot_INT_20230131.txt")
+          ch  (async/chan 100)]
+      (is (nil? (imp/process-file f ch :exclude nil))
+          ":exclude nil should be treated as 'exclude nothing', not throw NPE")
+      (async/close! ch))))
+
 
 

--- a/test/src/com/eldrix/hermes/owl_full_test.clj
+++ b/test/src/com/eldrix/hermes/owl_full_test.clj
@@ -1,0 +1,170 @@
+(ns com.eldrix.hermes.owl-full-test
+  "OWL reasoning tests using the full (unfiltered) reasoner.
+  All tests are ^:live ^:slow — the fixture only fires when :slow is not excluded."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [com.eldrix.hermes.impl.owl :as owl]
+            [com.eldrix.hermes.impl.scg :as scg]
+            [com.eldrix.hermes.impl.store :as store]))
+
+(def ^:private store-path "snomed.db/store.db")
+
+;;;; ── Shared fixture state ──
+
+(def ^:dynamic *store* nil)
+(def ^:dynamic *reasoner* nil)
+
+;;;; ── Fixture ──
+
+(defn- full-fixture [f]
+  (with-open [st (store/open-store store-path)]
+    (if-let [reasoner (owl/start-reasoner st {:n-parsers 4})]
+      (try
+        (binding [*store* st *reasoner* reasoner]
+          (f))
+        (finally
+          (owl/stop-reasoner reasoner)))
+      (println "WARNING: Skipping full OWL tests — no OWL axioms in" store-path))))
+
+(use-fixtures :once full-fixture)
+
+;;;; ── Helpers ──
+
+(defn- owl-subsumes?
+  [reasoner a-str b-str]
+  (let [a-cf (scg/ctu->cf (scg/str->ctu a-str))
+        b-cf (scg/ctu->cf (scg/str->ctu b-str))
+        result (owl/subsumes? reasoner a-cf b-cf)]
+    (contains? #{:equivalent :subsumes} result)))
+
+;;;; ── Classification against the full ontology ──
+
+(def ^:private classify-cases
+  [{:description        "MS has superclasses"
+    :expression         "24700007"
+    :has-supers         :any}
+   {:description        "appendectomy has superclasses"
+    :expression         "80146002"
+    :has-supers         :any}
+   {:description        "procedure has superclasses"
+    :expression         "71388002"
+    :has-supers         :any}
+   {:description        "fully-defined concept is equivalent to itself"
+    :expression         "80146002"
+    :has-equivalents    #{80146002}}
+   {:description        "normalized form loses equivalence but gains superclass"
+    :expression         "80146002"
+    :normalize?         true
+    :lacks-equivalents  #{80146002}
+    :has-supers         #{80146002}}
+   {:description        "post-coordinated expression classified under base"
+    :expression         "80146002 : 272741003 = 7771000"
+    :has-supers         #{80146002}}])
+
+(def ^:private subsumes-cases
+  [{:description "equivalent"    :a "80146002" :b "80146002"                        :expected :equivalent}
+   {:description "subsumes"      :a "80146002" :b "80146002 : 272741003 = 7771000"  :expected :subsumes}
+   {:description "subsumed-by"   :a "80146002 : 272741003 = 7771000" :b "80146002"  :expected :subsumed-by}
+   {:description "not-subsumed"  :a "80146002" :b "22298006"                        :expected :not-subsumed}])
+
+(deftest ^:live ^:slow classification
+  (let [st *store* reasoner *reasoner*]
+    (doseq [{:keys [description expression normalize?
+                    has-equivalents lacks-equivalents has-supers]} classify-cases]
+      (testing description
+        (let [cf     (if normalize?
+                       (scg/ctu->cf+normalize st (scg/str->ctu expression))
+                       (scg/ctu->cf (scg/str->ctu expression)))
+              result (owl/classify reasoner cf)]
+          (when has-equivalents
+            (doseq [cid has-equivalents]
+              (is (contains? (::owl/equivalent-concepts result) cid))))
+          (when lacks-equivalents
+            (doseq [cid lacks-equivalents]
+              (is (not (contains? (::owl/equivalent-concepts result) cid)))))
+          (when has-supers
+            (if (= :any has-supers)
+              (is (seq (::owl/direct-super-concepts result)))
+              (doseq [cid has-supers]
+                (is (contains? (::owl/direct-super-concepts result) cid))))))))))
+
+(deftest ^:live ^:slow classification-subsumes
+  (doseq [{:keys [description a b expected]} subsumes-cases]
+    (testing description
+      (let [cf-a (scg/ctu->cf (scg/str->ctu a))
+            cf-b (scg/ctu->cf (scg/str->ctu b))]
+        (is (= expected (owl/subsumes? *reasoner* cf-a cf-b)))))))
+
+;;;; ── Oracle tests against the full ontology ──
+
+(def ^:private subsumption-oracle-cases
+  [{:description "concept subsumes itself"
+    :a "73211009" :b "73211009" :expected true}
+   {:description "parent subsumes child (demyelinating disease > MS)"
+    :a "6118003" :b "24700007" :expected true}
+   {:description "child does not subsume parent"
+    :a "24700007" :b "6118003" :expected false}
+   {:description "unrefined subsumes refined"
+    :a "71388002" :b "71388002 : 260686004 = 129304002" :expected true}
+   {:description "refined does not subsume unrefined"
+    :a "71388002 : 260686004 = 129304002" :b "71388002" :expected false}
+   {:description "more specific attribute value is subsumed"
+    :a "64572001 : 363698007 = 39607008" :b "64572001 : 363698007 = 181216001"
+    :expected true}
+   {:description "unrelated attribute values — no subsumption"
+    :a "64572001 : 363698007 = 39607008" :b "64572001 : 363698007 = 64033007"
+    :expected false}
+   {:description "fully-defined concept subsumes itself refined"
+    :a "80146002" :b "80146002 : 272741003 = 7771000" :expected true}
+   {:description "identical expressions — mutual subsumption"
+    :a "80146002" :b "80146002" :expected true}
+   {:description "terms ignored"
+    :a "80146002 |Appendectomy|" :b "80146002" :expected true}])
+
+(def ^:private concept-pair-cases
+  [{:description "disease subsumes diabetes"
+    :a "64572001" :b "73211009" :expected true}
+   {:description "diabetes does not subsume disease"
+    :a "73211009" :b "64572001" :expected false}
+   {:description "clinical finding subsumes MS"
+    :a "404684003" :b "24700007" :expected true}
+   {:description "procedure subsumes appendectomy"
+    :a "71388002" :b "80146002" :expected true}
+   {:description "appendectomy does not subsume procedure"
+    :a "80146002" :b "71388002" :expected false}
+   {:description "procedure vs clinical finding — unrelated"
+    :a "71388002" :b "404684003" :expected false}
+   {:description "appendectomy does not subsume oophorectomy"
+    :a "80146002" :b "83152002" :expected false}])
+
+(deftest ^:live ^:slow oracle-subsumption
+  (testing "hand-written subsumption cases against full ontology"
+    (doseq [{:keys [description a b expected]} subsumption-oracle-cases]
+      (testing description
+        (is (= expected (owl-subsumes? *reasoner* a b))))))
+  (testing "concept-pair subsumption against full ontology"
+    (doseq [{:keys [description a b expected]} concept-pair-cases]
+      (testing description
+        (is (= expected (owl-subsumes? *reasoner* a b)))))))
+
+(deftest ^:live ^:slow oracle-nnf
+  (testing "NNF semantic correctness against full ontology"
+    (doseq [expr-str ["80146002"
+                       "80146002 : 272741003 = 7771000"
+                       "83152002"]]
+      (testing (str "NNF equivalence: " expr-str)
+        (let [cf  (scg/ctu->cf (scg/str->ctu expr-str))
+              nnf (owl/necessary-normal-form *reasoner* cf)
+              fwd (owl/subsumes? *reasoner* cf nnf)
+              nnf-eq (assoc nnf :cf/definition-status :equivalent-to)
+              rev (owl/subsumes? *reasoner* nnf-eq cf)]
+          (is (contains? #{:equivalent :subsumes} fwd)
+              (str "original should subsume NNF. Got: " fwd))
+          (is (contains? #{:equivalent :subsumes} rev)
+              (str "NNF (as equiv) should subsume original. Got: " rev)))))))
+
+(deftest ^:live ^:slow oracle-symmetry
+  (let [base    (scg/ctu->cf (scg/str->ctu "80146002"))
+        refined (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000"))]
+    (is (= :equivalent (owl/subsumes? *reasoner* base base)))
+    (is (= :subsumes (owl/subsumes? *reasoner* base refined)))
+    (is (= :subsumed-by (owl/subsumes? *reasoner* refined base)))))

--- a/test/src/com/eldrix/hermes/owl_full_test.clj
+++ b/test/src/com/eldrix/hermes/owl_full_test.clj
@@ -1,10 +1,15 @@
 (ns com.eldrix.hermes.owl-full-test
   "OWL reasoning tests using the full (unfiltered) reasoner.
   All tests are ^:live ^:slow — the fixture only fires when :slow is not excluded."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [com.eldrix.hermes.impl.owl :as owl]
             [com.eldrix.hermes.impl.scg :as scg]
             [com.eldrix.hermes.impl.store :as store]))
+
+(stest/instrument)
 
 (def ^:private store-path "snomed.db/store.db")
 
@@ -29,142 +34,105 @@
 
 ;;;; ── Helpers ──
 
-(defn- owl-subsumes?
-  [reasoner a-str b-str]
-  (let [a-cf (scg/ctu->cf (scg/str->ctu a-str))
-        b-cf (scg/ctu->cf (scg/str->ctu b-str))
-        result (owl/subsumes? reasoner a-cf b-cf)]
-    (contains? #{:equivalent :subsumes} result)))
+(defn- classify-str
+  "Classify an SCG string, returning the classification result map."
+  ([reasoner s] (owl/classify reasoner (scg/ctu->cf (scg/str->ctu s))))
+  ([reasoner store s normalize?]
+   (owl/classify reasoner (if normalize?
+                            (scg/ctu->cf+normalize store (scg/str->ctu s))
+                            (scg/ctu->cf (scg/str->ctu s))))))
 
-;;;; ── Classification against the full ontology ──
+;;;; ── Classification: round-trip equivalence for fully-defined concepts ──
+;; A fully-defined concept classified via ctu->cf should be found equivalent
+;; to itself. This validates the entire pipeline: parse → CF → OWL → ELK → result.
 
-(def ^:private classify-cases
-  [{:description        "MS has superclasses"
-    :expression         "24700007"
-    :has-supers         :any}
-   {:description        "appendectomy has superclasses"
-    :expression         "80146002"
-    :has-supers         :any}
-   {:description        "procedure has superclasses"
-    :expression         "71388002"
-    :has-supers         :any}
-   {:description        "fully-defined concept is equivalent to itself"
-    :expression         "80146002"
-    :has-equivalents    #{80146002}}
-   {:description        "normalized form loses equivalence but gains superclass"
-    :expression         "80146002"
-    :normalize?         true
-    :lacks-equivalents  #{80146002}
-    :has-supers         #{80146002}}
-   {:description        "post-coordinated expression classified under base"
-    :expression         "80146002 : 272741003 = 7771000"
-    :has-supers         #{80146002}}])
+(deftest ^:live ^:slow fully-defined-equivalence
+  (testing "appendectomy (80146002) is equivalent to itself"
+    (let [result (classify-str *reasoner* "80146002")]
+      (is (= #{80146002} (:equivalent-concepts result)))))
 
-(def ^:private subsumes-cases
-  [{:description "equivalent"    :a "80146002" :b "80146002"                        :expected :equivalent}
-   {:description "subsumes"      :a "80146002" :b "80146002 : 272741003 = 7771000"  :expected :subsumes}
-   {:description "subsumed-by"   :a "80146002 : 272741003 = 7771000" :b "80146002"  :expected :subsumed-by}
-   {:description "not-subsumed"  :a "80146002" :b "22298006"                        :expected :not-subsumed}])
+  (testing "oophorectomy (83152002) is equivalent to itself"
+    (let [result (classify-str *reasoner* "83152002")]
+      (is (= #{83152002} (:equivalent-concepts result))))))
 
-(deftest ^:live ^:slow classification
-  (let [st *store* reasoner *reasoner*]
-    (doseq [{:keys [description expression normalize?
-                    has-equivalents lacks-equivalents has-supers]} classify-cases]
-      (testing description
-        (let [cf     (if normalize?
-                       (scg/ctu->cf+normalize st (scg/str->ctu expression))
-                       (scg/ctu->cf (scg/str->ctu expression)))
-              result (owl/classify reasoner cf)]
-          (when has-equivalents
-            (doseq [cid has-equivalents]
-              (is (contains? (::owl/equivalent-concepts result) cid))))
-          (when lacks-equivalents
-            (doseq [cid lacks-equivalents]
-              (is (not (contains? (::owl/equivalent-concepts result) cid)))))
-          (when has-supers
-            (if (= :any has-supers)
-              (is (seq (::owl/direct-super-concepts result)))
-              (doseq [cid has-supers]
-                (is (contains? (::owl/direct-super-concepts result) cid))))))))))
+;;;; ── Normalization breaks equivalence but preserves subsumption ──
+;; Normalizing a fully-defined concept expands it to proximal primitives,
+;; losing the named concept identity. The normalized form should classify
+;; as a subtype of the original concept, not equivalent.
 
-(deftest ^:live ^:slow classification-subsumes
-  (doseq [{:keys [description a b expected]} subsumes-cases]
-    (testing description
-      (let [cf-a (scg/ctu->cf (scg/str->ctu a))
-            cf-b (scg/ctu->cf (scg/str->ctu b))]
-        (is (= expected (owl/subsumes? *reasoner* cf-a cf-b)))))))
+(deftest ^:live ^:slow normalized-loses-equivalence
+  (let [result (classify-str *reasoner* *store* "80146002" true)]
+    (is (not (contains? (:equivalent-concepts result) 80146002))
+        "normalized appendectomy should not be equivalent to the named concept")
+    (is (contains? (:direct-super-concepts result) 80146002)
+        "normalized appendectomy should have appendectomy as a direct superclass")))
 
-;;;; ── Oracle tests against the full ontology ──
+;;;; ── Post-coordination classifies under base concept ──
 
-(def ^:private subsumption-oracle-cases
-  [{:description "concept subsumes itself"
-    :a "73211009" :b "73211009" :expected true}
-   {:description "parent subsumes child (demyelinating disease > MS)"
-    :a "6118003" :b "24700007" :expected true}
-   {:description "child does not subsume parent"
-    :a "24700007" :b "6118003" :expected false}
-   {:description "unrefined subsumes refined"
-    :a "71388002" :b "71388002 : 260686004 = 129304002" :expected true}
-   {:description "refined does not subsume unrefined"
-    :a "71388002 : 260686004 = 129304002" :b "71388002" :expected false}
-   {:description "more specific attribute value is subsumed"
-    :a "64572001 : 363698007 = 39607008" :b "64572001 : 363698007 = 181216001"
-    :expected true}
-   {:description "unrelated attribute values — no subsumption"
-    :a "64572001 : 363698007 = 39607008" :b "64572001 : 363698007 = 64033007"
-    :expected false}
-   {:description "fully-defined concept subsumes itself refined"
-    :a "80146002" :b "80146002 : 272741003 = 7771000" :expected true}
-   {:description "identical expressions — mutual subsumption"
-    :a "80146002" :b "80146002" :expected true}
-   {:description "terms ignored"
-    :a "80146002 |Appendectomy|" :b "80146002" :expected true}])
+(deftest ^:live ^:slow post-coordinated-classified-under-base
+  (let [result (classify-str *reasoner* "80146002 : 272741003 = 7771000")]
+    (is (contains? (:direct-super-concepts result) 80146002)
+        "appendectomy + laterality should be classified under appendectomy")))
 
-(def ^:private concept-pair-cases
-  [{:description "disease subsumes diabetes"
-    :a "64572001" :b "73211009" :expected true}
-   {:description "diabetes does not subsume disease"
-    :a "73211009" :b "64572001" :expected false}
-   {:description "clinical finding subsumes MS"
-    :a "404684003" :b "24700007" :expected true}
-   {:description "procedure subsumes appendectomy"
-    :a "71388002" :b "80146002" :expected true}
-   {:description "appendectomy does not subsume procedure"
-    :a "80146002" :b "71388002" :expected false}
-   {:description "procedure vs clinical finding — unrelated"
-    :a "71388002" :b "404684003" :expected false}
-   {:description "appendectomy does not subsume oophorectomy"
-    :a "80146002" :b "83152002" :expected false}])
+;;;; ── Generative: classify random expressions and validate against spec ──
+
+(deftest ^:live ^:slow classify-conforms-to-spec
+  (doseq [cf (gen/sample (s/gen :cf/expression) 50)]
+    (let [result (owl/classify *reasoner* cf)]
+      (is (s/valid? ::owl/classification-result result)
+          (str "classify result does not conform to spec: "
+               (s/explain-str ::owl/classification-result result))))))
+
+;;;; ── Subsumption ──
+
+(deftest ^:live ^:slow subsumption
+  (let [classify (fn [s] (scg/ctu->cf (scg/str->ctu s)))]
+    (is (= :equivalent   (owl/subsumes? *reasoner* (classify "80146002") (classify "80146002"))))
+    (is (= :subsumes     (owl/subsumes? *reasoner* (classify "80146002") (classify "80146002 : 272741003 = 7771000"))))
+    (is (= :subsumed-by  (owl/subsumes? *reasoner* (classify "80146002 : 272741003 = 7771000") (classify "80146002"))))
+    (is (= :not-subsumed (owl/subsumes? *reasoner* (classify "80146002") (classify "22298006"))))))
+
+;;;; ── Oracle: structural subsumption agrees with reasoner ──
 
 (deftest ^:live ^:slow oracle-subsumption
-  (testing "hand-written subsumption cases against full ontology"
-    (doseq [{:keys [description a b expected]} subsumption-oracle-cases]
-      (testing description
-        (is (= expected (owl-subsumes? *reasoner* a b))))))
-  (testing "concept-pair subsumption against full ontology"
-    (doseq [{:keys [description a b expected]} concept-pair-cases]
-      (testing description
-        (is (= expected (owl-subsumes? *reasoner* a b)))))))
+  (let [owl-sub? (fn [a b]
+                   (contains? #{:equivalent :subsumes}
+                              (owl/subsumes? *reasoner*
+                                             (scg/ctu->cf (scg/str->ctu a))
+                                             (scg/ctu->cf (scg/str->ctu b)))))]
+    (testing "IS-A relationships"
+      (is (owl-sub? "6118003" "24700007")      "demyelinating disease subsumes MS")
+      (is (not (owl-sub? "24700007" "6118003")) "MS does not subsume demyelinating disease")
+      (is (owl-sub? "64572001" "73211009")      "disease subsumes diabetes")
+      (is (owl-sub? "404684003" "24700007")     "clinical finding subsumes MS")
+      (is (owl-sub? "71388002" "80146002")      "procedure subsumes appendectomy")
+      (is (not (owl-sub? "80146002" "71388002")) "appendectomy does not subsume procedure")
+      (is (not (owl-sub? "71388002" "404684003")) "procedure vs clinical finding — unrelated")
+      (is (not (owl-sub? "80146002" "83152002")) "appendectomy does not subsume oophorectomy"))
+
+    (testing "refinements"
+      (is (owl-sub? "71388002" "71388002 : 260686004 = 129304002")
+          "unrefined subsumes refined")
+      (is (not (owl-sub? "71388002 : 260686004 = 129304002" "71388002"))
+          "refined does not subsume unrefined")
+      (is (owl-sub? "64572001 : 363698007 = 39607008" "64572001 : 363698007 = 181216001")
+          "more specific attribute value is subsumed")
+      (is (not (owl-sub? "64572001 : 363698007 = 39607008" "64572001 : 363698007 = 64033007"))
+          "unrelated attribute values — no subsumption"))))
+
+;;;; ── NNF semantic correctness ──
 
 (deftest ^:live ^:slow oracle-nnf
-  (testing "NNF semantic correctness against full ontology"
-    (doseq [expr-str ["80146002"
-                       "80146002 : 272741003 = 7771000"
-                       "83152002"]]
-      (testing (str "NNF equivalence: " expr-str)
-        (let [cf  (scg/ctu->cf (scg/str->ctu expr-str))
-              nnf (owl/necessary-normal-form *reasoner* cf)
-              fwd (owl/subsumes? *reasoner* cf nnf)
-              nnf-eq (assoc nnf :cf/definition-status :equivalent-to)
-              rev (owl/subsumes? *reasoner* nnf-eq cf)]
-          (is (contains? #{:equivalent :subsumes} fwd)
-              (str "original should subsume NNF. Got: " fwd))
-          (is (contains? #{:equivalent :subsumes} rev)
-              (str "NNF (as equiv) should subsume original. Got: " rev)))))))
-
-(deftest ^:live ^:slow oracle-symmetry
-  (let [base    (scg/ctu->cf (scg/str->ctu "80146002"))
-        refined (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000"))]
-    (is (= :equivalent (owl/subsumes? *reasoner* base base)))
-    (is (= :subsumes (owl/subsumes? *reasoner* base refined)))
-    (is (= :subsumed-by (owl/subsumes? *reasoner* refined base)))))
+  (doseq [expr-str ["80146002"
+                     "80146002 : 272741003 = 7771000"
+                     "83152002"]]
+    (testing (str "NNF equivalence: " expr-str)
+      (let [cf  (scg/ctu->cf (scg/str->ctu expr-str))
+            nnf (owl/necessary-normal-form *reasoner* cf)
+            fwd (owl/subsumes? *reasoner* cf nnf)
+            nnf-eq (assoc nnf :cf/definition-status :equivalent-to)
+            rev (owl/subsumes? *reasoner* nnf-eq cf)]
+        (is (contains? #{:equivalent :subsumes} fwd)
+            (str "original should subsume NNF. Got: " fwd))
+        (is (contains? #{:equivalent :subsumes} rev)
+            (str "NNF (as equiv) should subsume original. Got: " rev))))))

--- a/test/src/com/eldrix/hermes/owl_oracle_test.clj
+++ b/test/src/com/eldrix/hermes/owl_oracle_test.clj
@@ -7,10 +7,16 @@
   The OWL side uses ctu->cf to preserve concept identity — the reasoner already
   knows concept definitions from the ontology, so normalization would lose
   information."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [com.eldrix.hermes.impl.owl :as owl]
             [com.eldrix.hermes.impl.scg :as scg]
-            [com.eldrix.hermes.impl.store :as store]))
+            [com.eldrix.hermes.impl.store :as store]
+            [com.eldrix.hermes.snomed :as snomed]))
+
+(stest/instrument)
 
 (def ^:private store-path "snomed.db/store.db")
 
@@ -80,40 +86,6 @@
 
 ;;;; ── Classification tests ──
 
-(def ^:private classify-cases
-  "Declarative classification test cases.
-  Each case specifies an SCG expression (or CF) and what to check in the result.
-  Keys:
-    :description  — test label
-    :expression   — SCG string (classified via ctu->cf)
-    :normalize?   — if true, classify via ctu->cf+normalize instead of ctu->cf
-    :has-equivalents   — concept IDs that must appear in ::equivalent-concepts
-    :lacks-equivalents — concept IDs that must NOT appear in ::equivalent-concepts
-    :has-supers        — concept IDs that must appear in ::direct-super-concepts
-    :has-pps           — true if ::proximal-primitive-supertypes must be non-empty"
-  [{:description   "concepts have superclasses (MS)"
-    :expression    "24700007"
-    :has-supers    :any}
-   {:description   "concepts have superclasses (appendectomy)"
-    :expression    "80146002"
-    :has-supers    :any}
-   {:description   "concepts have superclasses (procedure)"
-    :expression    "71388002"
-    :has-supers    :any}
-   {:description   "fully-defined concept is equivalent to itself"
-    :expression    "80146002"
-    :has-equivalents #{80146002}}
-   {:description   "ctu->cf+normalize loses equivalence for fully-defined concepts"
-    :expression    "80146002"
-    :normalize?    true
-    :lacks-equivalents #{80146002}
-    :has-supers        #{80146002}}
-   {:description   "post-coordinated expression is subtype of base concept"
-    :expression    "80146002 : 272741003 = 7771000"
-    :has-supers    #{80146002}}
-   {:description   "classify includes proximal primitive supertypes"
-    :expression    "80146002"
-    :has-pps       true}])
 
 (def ^:private subsumes-cases
   "Declarative subsumption test cases for owl/subsumes?."
@@ -126,22 +98,6 @@
    {:description "unrelated expressions"
     :a "80146002" :b "22298006" :expected :not-subsumed}])
 
-(def ^:private nnf-cases
-  "Declarative NNF test cases."
-  [{:description     "NNF is primitive with focus concepts"
-    :expression      "80146002"
-    :def-status      :subtype-of
-    :has-groups?     true
-    :has-group-attr  260686004
-    :pps-match?      true}
-   {:description     "NNF merges user refinements with inherited"
-    :expression      "80146002 : 272741003 = 7771000"
-    :has-ungrouped   [272741003 [:concept 7771000]]
-    :has-groups?     true}
-   {:description     "NNF of post-coordinated grouped expression"
-    :expression      "71388002 : { 260686004 = 129304002 }"
-    :def-status      :subtype-of
-    :has-focus?      true}])
 
 (def ^:private ecl-cases
   "Declarative cf->ecl test cases."
@@ -153,30 +109,33 @@
     :contains    ["272741003 = << 7771000"]
     :excludes    ["80146002"]}])
 
+(defn- classify-str
+  ([reasoner s] (owl/classify reasoner (scg/ctu->cf (scg/str->ctu s))))
+  ([reasoner store s] (owl/classify reasoner (scg/ctu->cf+normalize store (scg/str->ctu s)))))
+
 (deftest ^:live classification
-  (let [st *store* reasoner *reasoner*]
-    (doseq [{:keys [description expression normalize?
-                    has-equivalents lacks-equivalents has-supers has-pps]} classify-cases]
-      (testing description
-        (let [cf     (if normalize?
-                       (scg/ctu->cf+normalize st (scg/str->ctu expression))
-                       (scg/ctu->cf (scg/str->ctu expression)))
-              result (owl/classify reasoner cf)]
-          (is (set? (::owl/equivalent-concepts result)))
-          (is (set? (::owl/direct-super-concepts result)))
-          (when has-equivalents
-            (doseq [cid has-equivalents]
-              (is (contains? (::owl/equivalent-concepts result) cid))))
-          (when lacks-equivalents
-            (doseq [cid lacks-equivalents]
-              (is (not (contains? (::owl/equivalent-concepts result) cid)))))
-          (when has-supers
-            (if (= :any has-supers)
-              (is (seq (::owl/direct-super-concepts result)))
-              (doseq [cid has-supers]
-                (is (contains? (::owl/direct-super-concepts result) cid)))))
-          (when has-pps
-            (is (seq (::owl/proximal-primitive-supertypes result)))))))))
+  (testing "fully-defined concept is equivalent to itself"
+    (let [result (classify-str *reasoner* "80146002")]
+      (is (= #{80146002} (:equivalent-concepts result)))))
+
+  (testing "direct supers match stated IS-A parents from store"
+    (let [result       (classify-str *reasoner* "80146002")
+          store-parents (store/parent-relationships-of-type *store* 80146002 snomed/IsA)]
+      (is (= store-parents (:direct-super-concepts result)))))
+
+  (testing "proximal primitive supertypes are a subset of all ancestors"
+    (let [result     (classify-str *reasoner* "80146002")
+          all-ancestors (store/all-parents *store* 80146002)]
+      (is (every? all-ancestors (:proximal-primitive-supertypes result)))))
+
+  (testing "normalized form loses equivalence but gains superclass"
+    (let [result (classify-str *reasoner* *store* "80146002")]
+      (is (not (contains? (:equivalent-concepts result) 80146002)))
+      (is (contains? (:direct-super-concepts result) 80146002))))
+
+  (testing "post-coordinated expression classified under base concept"
+    (let [result (classify-str *reasoner* "80146002 : 272741003 = 7771000")]
+      (is (contains? (:direct-super-concepts result) 80146002)))))
 
 (deftest ^:live classification-subsumes
   (doseq [{:keys [description a b expected]} subsumes-cases]
@@ -186,26 +145,36 @@
         (is (= expected (owl/subsumes? *reasoner* cf-a cf-b)))))))
 
 (deftest ^:live classification-nnf
-  (doseq [{:keys [description expression def-status has-groups? has-group-attr
-                  has-ungrouped has-focus? pps-match?]} nnf-cases]
-    (testing description
-      (let [cf  (scg/ctu->cf (scg/str->ctu expression))
-            nnf (owl/necessary-normal-form *reasoner* cf)]
-        (when def-status
-          (is (= def-status (:cf/definition-status nnf))))
-        (when has-focus?
-          (is (seq (:cf/focus-concepts nnf))))
-        (when has-groups?
-          (is (seq (:cf/groups nnf))))
-        (when has-group-attr
-          (is (some (fn [group]
-                      (some (fn [[type-id _]] (= type-id has-group-attr)) group))
-                    (:cf/groups nnf))))
-        (when has-ungrouped
-          (is (contains? (:cf/ungrouped nnf) has-ungrouped)))
-        (when pps-match?
-          (is (= (:cf/focus-concepts nnf)
-                 (::owl/proximal-primitive-supertypes (owl/classify *reasoner* cf)))))))))
+  (testing "appendectomy NNF is primitive with PPS as focus concepts"
+    (let [cf     (scg/ctu->cf (scg/str->ctu "80146002"))
+          nnf    (owl/necessary-normal-form *reasoner* cf)
+          result (owl/classify *reasoner* cf)]
+      (is (= :subtype-of (:cf/definition-status nnf)))
+      (is (= (:cf/focus-concepts nnf) (:proximal-primitive-supertypes result))
+          "NNF focus concepts should be the proximal primitive supertypes")
+      (is (every? (store/all-parents *store* 80146002) (:cf/focus-concepts nnf))
+          "NNF focus concepts should be ancestors of the original concept")
+      (is (some (fn [group]
+                  (some (fn [[type-id _]] (= type-id 260686004)) group))
+                (:cf/groups nnf))
+          "NNF should contain method (260686004) in a group")))
+
+  (testing "appendectomy+laterality NNF preserves user refinement"
+    (let [cf  (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000"))
+          nnf (owl/necessary-normal-form *reasoner* cf)]
+      (is (= :subtype-of (:cf/definition-status nnf)))
+      (is (contains? (:cf/ungrouped nnf) [272741003 [:concept 7771000]])
+          "laterality refinement should be preserved in NNF")
+      (is (seq (:cf/groups nnf))
+          "inherited groups should also be present")))
+
+  (testing "procedure+method NNF focus concepts match classification PPS"
+    (let [cf     (scg/ctu->cf (scg/str->ctu "71388002 : { 260686004 = 129304002 }"))
+          nnf    (owl/necessary-normal-form *reasoner* cf)
+          result (owl/classify *reasoner* cf)]
+      (is (= :subtype-of (:cf/definition-status nnf)))
+      (is (= (:cf/focus-concepts nnf) (:proximal-primitive-supertypes result))
+          "NNF focus concepts should be the proximal primitive supertypes"))))
 
 (deftest ^:live classification-ecl
   (doseq [{:keys [description expression expected contains excludes]} ecl-cases]
@@ -259,42 +228,48 @@
      :structural structural :owl owl-result
      :agree? (= structural owl-result)}))
 
-;;;; ── Expression generation using the SCG pipeline ──
+;;;; ── Expression generation ──
 
 (defn- render-cf
   "Render a CF expression to an SCG string via the existing pipeline."
   [cf]
   (scg/ctu->str (scg/cf->ctu cf)))
 
-(defn- concept->cf
-  "Get a concept's definition as CF, using the real SCG infrastructure."
-  [st concept-id]
-  (scg/ctu->cf (scg/concept->ctu st concept-id)))
+(defn gen-concept-id
+  "Generator that picks from a collection of concept IDs."
+  [concept-ids]
+  (gen/elements (vec concept-ids)))
 
-(defn- add-random-refinement
-  "Add a random subset of a concept's own attributes as extra refinements.
-  Works at the CF level — no string manipulation."
-  [st concept-id cf]
-  (let [full-cf (concept->cf st concept-id)
-        pick (fn [coll n] (when-let [s (seq coll)] (take (rand-int (inc (min (count s) n))) (shuffle s))))
-        extra-ungrouped (pick (:cf/ungrouped full-cf) 2)
-        extra-groups (pick (:cf/groups full-cf) 2)]
-    (cond-> cf
-      (seq extra-ungrouped) (update :cf/ungrouped (fnil into #{}) extra-ungrouped)
-      (seq extra-groups) (update :cf/groups (fnil into #{}) extra-groups))))
+(defn gen-attribute-value
+  "Generator for a CF attribute value: concept reference or nested expression."
+  [concept-ids]
+  (gen/frequency
+    [[8 (gen/fmap (fn [id] [:concept id]) (gen-concept-id concept-ids))]
+     [2 (gen/fmap (fn [id] [:expression {:cf/definition-status :subtype-of
+                                          :cf/focus-concepts #{id}}])
+                  (gen-concept-id concept-ids))]]))
 
-(defn- generate-expression-pair
-  "Generate a random SCG expression pair from the test concept set."
-  [st]
-  (let [ids (vec test-concept-ids)
-        rand-id #(nth ids (rand-int (count ids)))
-        make (fn []
-               (let [cid (rand-id)
-                     cf (scg/ctu->cf (scg/str->ctu (str cid)))]
-                 (if (< (rand) 0.3)
-                   (render-cf (add-random-refinement st cid cf))
-                   (str cid))))]
-    [(make) (make)]))
+(defn gen-attribute
+  "Generator for a CF attribute [type-id value]."
+  [concept-ids]
+  (gen/tuple (gen-concept-id concept-ids) (gen-attribute-value concept-ids)))
+
+(defn gen-cf-expression
+  "Generator for a CF expression using real concept IDs.
+  Produces bare concepts, concepts with ungrouped attributes, grouped
+  attributes, and nested subexpressions."
+  [concept-ids]
+  (gen/bind (gen/tuple (gen/fmap set (gen/not-empty (gen/vector (gen-concept-id concept-ids) 1 2)))
+                       (gen/elements [:subtype-of :equivalent-to])
+                       (gen/vector (gen-attribute concept-ids) 0 3)
+                       (gen/vector (gen/fmap set (gen/not-empty (gen/vector (gen-attribute concept-ids) 1 3)))
+                                  0 2))
+    (fn [[focus def-status ungrouped groups]]
+      (gen/return
+        (cond-> {:cf/definition-status def-status
+                 :cf/focus-concepts focus}
+          (seq ungrouped) (assoc :cf/ungrouped (set ungrouped))
+          (seq groups) (assoc :cf/groups (set groups)))))))
 
 ;;;; ── Test 1: Hand-written cases ──
 
@@ -433,41 +408,31 @@
    {:description "appendectomy does not subsume oophorectomy"
     :a "80146002" :b "83152002" :structural false}
    {:description "oophorectomy does not subsume appendectomy"
-    :a "83152002" :b "80146002" :structural false}])
+    :a "83152002" :b "80146002" :structural false}
+
+   ;; Nested expressions: attribute value is a subexpression
+   {:description "nested: disease+site subsumes disease+site with more specific nested site"
+    :a "64572001 : 363698007 = (39607008)"
+    :b "64572001 : 363698007 = (39607008 : 272741003 = 7771000)"
+    :structural true}
+   {:description "nested: more specific nested site does not subsume less specific"
+    :a "64572001 : 363698007 = (39607008 : 272741003 = 7771000)"
+    :b "64572001 : 363698007 = (39607008)"
+    :structural false}
+   {:description "nested: procedure with nested method subsumes procedure with more refined nested method"
+    :a "71388002 : { 260686004 = (129304002) }"
+    :b "71388002 : { 260686004 = (129304002 : 272741003 = 7771000) }"
+    :structural true}
+   {:description "nested: identical nested expressions are equivalent"
+    :a "64572001 : 363698007 = (39607008 : 272741003 = 7771000)"
+    :b "64572001 : 363698007 = (39607008 : 272741003 = 7771000)"
+    :structural true}
+   {:description "nested: different nested values — no subsumption"
+    :a "64572001 : 363698007 = (39607008 : 272741003 = 7771000)"
+    :b "64572001 : 363698007 = (39607008 : 272741003 = 24028007)"
+    :structural false}])
 
 ;;;; ── Test 3: Generated refinement pairs ──
-
-(defn- generate-refinement-pairs
-  "Generate subsumption pairs from real concept properties using the SCG pipeline.
-  For each concept, tests: base subsumes base+extra-attr (and the converse)."
-  [st]
-  (let [concepts [80146002 83152002 73211009 24700007 22298006]]
-    (mapcat
-      (fn [cid]
-        (let [cf (concept->cf st cid)
-              base (str cid)
-              ungrouped (seq (:cf/ungrouped cf))
-              groups (seq (:cf/groups cf))]
-          (concat
-            ;; Base subsumes base + single ungrouped attr
-            (for [attr (take 3 ungrouped)
-                  :let [refined-cf (update cf :cf/ungrouped (fnil conj #{}) attr)
-                        refined-str (render-cf refined-cf)]]
-              {:description (str cid " subsumes " cid " + ungrouped attr")
-               :a base :b refined-str :structural true})
-            ;; Base + single ungrouped attr does not subsume base
-            (for [attr (take 3 ungrouped)
-                  :let [refined-cf (update cf :cf/ungrouped (fnil conj #{}) attr)
-                        refined-str (render-cf refined-cf)]]
-              {:description (str cid " + ungrouped attr does not subsume " cid)
-               :a refined-str :b base :structural false})
-            ;; Base subsumes base + single group
-            (for [g (take 2 groups)
-                  :let [refined-cf (update cf :cf/groups (fnil conj #{}) g)
-                        refined-str (render-cf refined-cf)]]
-              {:description (str cid " subsumes " cid " + group")
-               :a base :b refined-str :structural true}))))
-      concepts)))
 
 ;;;; ── Test runners ──
 
@@ -483,29 +448,17 @@
       (is (= structural (owl-subsumes? *reasoner* a b))
           (str "OWL disagrees — expected: " structural)))))
 
-(deftest ^:live oracle-generated-refinements
-  (let [pairs (generate-refinement-pairs *store*)]
-    (println "  Testing" (count pairs) "generated refinement pairs")
-    (doseq [{:keys [description a b structural]} pairs]
-      (testing description
-        (is (= structural (owl-subsumes? *reasoner* a b))
-            (str "OWL disagrees — expected: " structural))))))
-
 (deftest ^:live oracle-random-agreement
-  (let [pairs (repeatedly 200 #(generate-expression-pair *store*))
-        results (mapv (fn [[a b]] (check-oracle-agreement *store* *reasoner* a b)) pairs)
+  (let [expressions (gen/sample (gen-cf-expression test-concept-ids) 200)
+        pairs (partition 2 expressions)
+        results (mapv (fn [[a b]]
+                        (check-oracle-agreement *store* *reasoner*
+                                                (render-cf a) (render-cf b)))
+                      pairs)
         agreements (count (filter :agree? results))
-        disagreements (remove :agree? results)
-        total (count results)
-        pct (if (pos? total) (* 100.0 (/ agreements total)) 100.0)]
-    (println (format "  Oracle agreement: %d/%d (%.1f%%)" agreements total pct))
-    (when (seq disagreements)
-      (println "  Disagreements (may be GCI gaps):")
-      (doseq [{:keys [a b structural owl]} (take 10 disagreements)]
-        (println (str "    " a (if structural " ⊒ " " ⋢ ") b
-                      " — structural:" structural " owl:" owl))))
+        total (count results)]
     (is (> (/ (double agreements) total) 0.90)
-        (str "Agreement rate " (format "%.1f%%" pct) " is below 90% threshold"))))
+        (str "Agreement rate below 90% threshold"))))
 
 ;;;; ── Equivalence discovery ──
 
@@ -513,18 +466,18 @@
   (testing "fully-defined concept equivalent to itself via ctu->cf"
     (let [cf (scg/ctu->cf (scg/str->ctu "80146002"))
           result (owl/classify *reasoner* cf)]
-      (is (contains? (::owl/equivalent-concepts result) 80146002))))
+      (is (contains? (:equivalent-concepts result) 80146002))))
 
   (testing "normalized form loses equivalence but gains superclass"
     (let [cf (scg/ctu->cf+normalize *store* (scg/str->ctu "80146002"))
           result (owl/classify *reasoner* cf)]
-      (is (not (contains? (::owl/equivalent-concepts result) 80146002)))
-      (is (contains? (::owl/direct-super-concepts result) 80146002))))
+      (is (not (contains? (:equivalent-concepts result) 80146002)))
+      (is (contains? (:direct-super-concepts result) 80146002))))
 
   (testing "post-coordinated expression classified under base concept"
     (let [cf (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000"))
           result (owl/classify *reasoner* cf)]
-      (is (contains? (::owl/direct-super-concepts result) 80146002)))))
+      (is (contains? (:direct-super-concepts result) 80146002)))))
 
 ;;;; ── Normalize validation via classification ──
 
@@ -543,11 +496,11 @@
             norm-cf     (scg/ctu->cf+normalize *store* parsed)
             ctu-result  (owl/classify *reasoner* ctu-cf)
             norm-result (owl/classify *reasoner* norm-cf)]
-        (is (or (seq (::owl/equivalent-concepts ctu-result))
-                (seq (::owl/direct-super-concepts ctu-result)))
+        (is (or (seq (:equivalent-concepts ctu-result))
+                (seq (:direct-super-concepts ctu-result)))
             "ctu->cf form should classify")
-        (is (or (seq (::owl/equivalent-concepts norm-result))
-                (seq (::owl/direct-super-concepts norm-result)))
+        (is (or (seq (:equivalent-concepts norm-result))
+                (seq (:direct-super-concepts norm-result)))
             "normalized form should classify")))))
 
 ;;;; ── NNF semantic validation ──
@@ -569,18 +522,25 @@
           (is (contains? #{:equivalent :subsumes} rev)
               (str "NNF (as equiv) should subsume original (NNF at least as general). Got: " rev
                    "\nNNF: " (pr-str nnf)))))))
-  (testing "NNF contains inherited relationships"
-    (let [cf  (scg/ctu->cf (scg/str->ctu "80146002"))
-          nnf (owl/necessary-normal-form *reasoner* cf)]
-      (is (seq (:cf/groups nnf))
-          "appendectomy NNF should have inherited groups")))
+  (testing "NNF contains inherited relationships from store"
+    (let [cf            (scg/ctu->cf (scg/str->ctu "80146002"))
+          nnf           (owl/necessary-normal-form *reasoner* cf)
+          store-rels    (store/parent-relationships *store* 80146002)
+          store-methods (get store-rels 260686004)]
+      (is (some (fn [group]
+                  (some (fn [[type-id [_ val]]] (and (= type-id 260686004) (contains? store-methods val)))
+                        group))
+                (:cf/groups nnf))
+          "NNF groups should contain method attributes matching the store")))
   (testing "NNF preserves user refinements alongside inherited"
     (let [cf  (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000"))
           nnf (owl/necessary-normal-form *reasoner* cf)]
       (is (contains? (:cf/ungrouped nnf) [272741003 [:concept 7771000]])
           "laterality should be in NNF")
-      (is (seq (:cf/groups nnf))
-          "inherited groups should also be present"))))
+      (is (some (fn [group]
+                  (some (fn [[type-id _]] (= type-id 260686004)) group))
+                (:cf/groups nnf))
+          "inherited groups with method attribute should be present"))))
 
 ;;;; ── Bidirectional subsumption agreement ──
 

--- a/test/src/com/eldrix/hermes/owl_oracle_test.clj
+++ b/test/src/com/eldrix/hermes/owl_oracle_test.clj
@@ -1,0 +1,608 @@
+(ns com.eldrix.hermes.owl-oracle-test
+  "OWL reasoning tests using a subset reasoner (filtered to test concepts).
+  Includes classification tests and oracle cross-checks of structural
+  subsumption against the OWL reasoner.
+
+  The structural side normalizes internally (scg/subsumes? calls ctu->cf+normalize).
+  The OWL side uses ctu->cf to preserve concept identity — the reasoner already
+  knows concept definitions from the ontology, so normalization would lose
+  information."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [com.eldrix.hermes.impl.owl :as owl]
+            [com.eldrix.hermes.impl.scg :as scg]
+            [com.eldrix.hermes.impl.store :as store]))
+
+(def ^:private store-path "snomed.db/store.db")
+
+;;;; ── Shared fixture state ──
+
+(def ^:dynamic *store* nil)
+(def ^:dynamic *reasoner* nil)
+
+;;;; ── Seed concepts spanning multiple hierarchies ──
+
+(def ^:private test-concept-ids
+  "Concepts from diverse hierarchies for broad oracle coverage."
+  #{24700007     ;; MS
+    6118003      ;; Demyelinating disease
+    73211009     ;; Diabetes
+    22298006     ;; MI
+    195967001    ;; Asthma
+    19242006     ;; Pulmonary edema
+    404684003    ;; Clinical finding
+    80146002     ;; Appendectomy
+    71388002     ;; Procedure
+    83152002     ;; Oophorectomy
+    38102005     ;; Cholecystectomy
+    397956004    ;; Hip replacement
+    129304002    ;; Excision
+    39607008     ;; Lung
+    181216001    ;; Entire lung
+    64033007     ;; Kidney
+    66754008     ;; Appendix
+    15497006     ;; Ovary
+    31435000     ;; Fallopian tube
+    71341001     ;; Femur
+    80891009     ;; Heart
+    272741003    ;; Laterality
+    7771000      ;; Left
+    24028007     ;; Right
+    363698007    ;; Finding site
+    260686004    ;; Method
+    405813007    ;; Procedure site
+    116676008    ;; Associated morphology
+    72704001     ;; Fracture
+    79654002     ;; Edema
+    32693004     ;; Demyelination
+    55641003     ;; Infarct
+    64572001})   ;; Disease
+
+(defn- make-item-filter
+  "Build an item filter that includes all ancestors of the test concepts."
+  [st]
+  (let [all-ids (store/all-parents st test-concept-ids)]
+    (fn [item] (contains? all-ids (:referencedComponentId item)))))
+
+;;;; ── Fixture ──
+
+(defn- live-fixture [f]
+  (with-open [st (store/open-store store-path)]
+    (if-let [reasoner (owl/start-reasoner st {:n-parsers 4
+                                               :item-filter (make-item-filter st)})]
+      (try
+        (binding [*store* st *reasoner* reasoner]
+          (f))
+        (finally
+          (owl/stop-reasoner reasoner)))
+      (println "WARNING: Skipping OWL subset tests — no OWL axioms in" store-path))))
+
+(use-fixtures :once live-fixture)
+
+;;;; ── Classification tests ──
+
+(def ^:private classify-cases
+  "Declarative classification test cases.
+  Each case specifies an SCG expression (or CF) and what to check in the result.
+  Keys:
+    :description  — test label
+    :expression   — SCG string (classified via ctu->cf)
+    :normalize?   — if true, classify via ctu->cf+normalize instead of ctu->cf
+    :has-equivalents   — concept IDs that must appear in ::equivalent-concepts
+    :lacks-equivalents — concept IDs that must NOT appear in ::equivalent-concepts
+    :has-supers        — concept IDs that must appear in ::direct-super-concepts
+    :has-pps           — true if ::proximal-primitive-supertypes must be non-empty"
+  [{:description   "concepts have superclasses (MS)"
+    :expression    "24700007"
+    :has-supers    :any}
+   {:description   "concepts have superclasses (appendectomy)"
+    :expression    "80146002"
+    :has-supers    :any}
+   {:description   "concepts have superclasses (procedure)"
+    :expression    "71388002"
+    :has-supers    :any}
+   {:description   "fully-defined concept is equivalent to itself"
+    :expression    "80146002"
+    :has-equivalents #{80146002}}
+   {:description   "ctu->cf+normalize loses equivalence for fully-defined concepts"
+    :expression    "80146002"
+    :normalize?    true
+    :lacks-equivalents #{80146002}
+    :has-supers        #{80146002}}
+   {:description   "post-coordinated expression is subtype of base concept"
+    :expression    "80146002 : 272741003 = 7771000"
+    :has-supers    #{80146002}}
+   {:description   "classify includes proximal primitive supertypes"
+    :expression    "80146002"
+    :has-pps       true}])
+
+(def ^:private subsumes-cases
+  "Declarative subsumption test cases for owl/subsumes?."
+  [{:description "equivalent expressions"
+    :a "80146002" :b "80146002" :expected :equivalent}
+   {:description "base concept subsumes refined expression"
+    :a "80146002" :b "80146002 : 272741003 = 7771000" :expected :subsumes}
+   {:description "refined expression is subsumed by base"
+    :a "80146002 : 272741003 = 7771000" :b "80146002" :expected :subsumed-by}
+   {:description "unrelated expressions"
+    :a "80146002" :b "22298006" :expected :not-subsumed}])
+
+(def ^:private nnf-cases
+  "Declarative NNF test cases."
+  [{:description     "NNF is primitive with focus concepts"
+    :expression      "80146002"
+    :def-status      :subtype-of
+    :has-groups?     true
+    :has-group-attr  260686004
+    :pps-match?      true}
+   {:description     "NNF merges user refinements with inherited"
+    :expression      "80146002 : 272741003 = 7771000"
+    :has-ungrouped   [272741003 [:concept 7771000]]
+    :has-groups?     true}
+   {:description     "NNF of post-coordinated grouped expression"
+    :expression      "71388002 : { 260686004 = 129304002 }"
+    :def-status      :subtype-of
+    :has-focus?      true}])
+
+(def ^:private ecl-cases
+  "Declarative cf->ecl test cases."
+  [{:description "fully-defined concept returns << equivalent"
+    :expression  "80146002"
+    :expected    "<< 80146002"}
+   {:description "post-coordinated expression uses NNF"
+    :expression  "80146002 : 272741003 = 7771000"
+    :contains    ["272741003 = << 7771000"]
+    :excludes    ["80146002"]}])
+
+(deftest ^:live classification
+  (let [st *store* reasoner *reasoner*]
+    (doseq [{:keys [description expression normalize?
+                    has-equivalents lacks-equivalents has-supers has-pps]} classify-cases]
+      (testing description
+        (let [cf     (if normalize?
+                       (scg/ctu->cf+normalize st (scg/str->ctu expression))
+                       (scg/ctu->cf (scg/str->ctu expression)))
+              result (owl/classify reasoner cf)]
+          (is (set? (::owl/equivalent-concepts result)))
+          (is (set? (::owl/direct-super-concepts result)))
+          (when has-equivalents
+            (doseq [cid has-equivalents]
+              (is (contains? (::owl/equivalent-concepts result) cid))))
+          (when lacks-equivalents
+            (doseq [cid lacks-equivalents]
+              (is (not (contains? (::owl/equivalent-concepts result) cid)))))
+          (when has-supers
+            (if (= :any has-supers)
+              (is (seq (::owl/direct-super-concepts result)))
+              (doseq [cid has-supers]
+                (is (contains? (::owl/direct-super-concepts result) cid)))))
+          (when has-pps
+            (is (seq (::owl/proximal-primitive-supertypes result)))))))))
+
+(deftest ^:live classification-subsumes
+  (doseq [{:keys [description a b expected]} subsumes-cases]
+    (testing description
+      (let [cf-a (scg/ctu->cf (scg/str->ctu a))
+            cf-b (scg/ctu->cf (scg/str->ctu b))]
+        (is (= expected (owl/subsumes? *reasoner* cf-a cf-b)))))))
+
+(deftest ^:live classification-nnf
+  (doseq [{:keys [description expression def-status has-groups? has-group-attr
+                  has-ungrouped has-focus? pps-match?]} nnf-cases]
+    (testing description
+      (let [cf  (scg/ctu->cf (scg/str->ctu expression))
+            nnf (owl/necessary-normal-form *reasoner* cf)]
+        (when def-status
+          (is (= def-status (:cf/definition-status nnf))))
+        (when has-focus?
+          (is (seq (:cf/focus-concepts nnf))))
+        (when has-groups?
+          (is (seq (:cf/groups nnf))))
+        (when has-group-attr
+          (is (some (fn [group]
+                      (some (fn [[type-id _]] (= type-id has-group-attr)) group))
+                    (:cf/groups nnf))))
+        (when has-ungrouped
+          (is (contains? (:cf/ungrouped nnf) has-ungrouped)))
+        (when pps-match?
+          (is (= (:cf/focus-concepts nnf)
+                 (::owl/proximal-primitive-supertypes (owl/classify *reasoner* cf)))))))))
+
+(deftest ^:live classification-ecl
+  (doseq [{:keys [description expression expected contains excludes]} ecl-cases]
+    (testing description
+      (let [cf  (scg/ctu->cf (scg/str->ctu expression))
+            ecl (owl/cf->ecl *reasoner* cf)]
+        (when expected
+          (is (= expected ecl)))
+        (when contains
+          (doseq [s contains]
+            (is (.contains ecl s))))
+        (when excludes
+          (doseq [s excludes]
+            (is (not (.contains ecl s)))))))))
+
+(deftest ^:live classification-ecl-determinism
+  (let [cf  (scg/ctu->cf (scg/str->ctu "80146002"))
+        ecls (repeatedly 5 #(owl/cf->ecl *reasoner* cf))]
+    (is (apply = ecls))))
+
+(deftest ^:live classification-property-chains
+  (let [chains (owl/extract-property-chains (:ontology *reasoner*))]
+    (doseq [[super-id chain-set] chains
+            chain chain-set]
+      (is (= 2 (count chain))
+          (str "property chain for " super-id " has " (count chain)
+               " links: " (pr-str chain))))))
+
+;;;; ── Oracle comparison helpers ──
+
+(defn- owl-subsumes?
+  "Use the OWL reasoner to test whether expression a subsumes expression b.
+  Uses ctu->cf to preserve concept identity."
+  [reasoner a-str b-str]
+  (let [a-cf (scg/ctu->cf (scg/str->ctu a-str))
+        b-cf (scg/ctu->cf (scg/str->ctu b-str))
+        result (owl/subsumes? reasoner a-cf b-cf)]
+    (contains? #{:equivalent :subsumes} result)))
+
+(defn- structural-subsumes?
+  "Use structural subsumption to test whether expression a subsumes b."
+  [st a-str b-str]
+  (scg/subsumes? st (scg/str->ctu a-str) (scg/str->ctu b-str)))
+
+(defn- check-oracle-agreement
+  "Compare structural and OWL subsumption for a pair, returning a result map."
+  [st reasoner a-str b-str]
+  (let [structural (structural-subsumes? st a-str b-str)
+        owl-result (owl-subsumes? reasoner a-str b-str)]
+    {:a a-str :b b-str
+     :structural structural :owl owl-result
+     :agree? (= structural owl-result)}))
+
+;;;; ── Expression generation using the SCG pipeline ──
+
+(defn- render-cf
+  "Render a CF expression to an SCG string via the existing pipeline."
+  [cf]
+  (scg/ctu->str (scg/cf->ctu cf)))
+
+(defn- concept->cf
+  "Get a concept's definition as CF, using the real SCG infrastructure."
+  [st concept-id]
+  (scg/ctu->cf (scg/concept->ctu st concept-id)))
+
+(defn- add-random-refinement
+  "Add a random subset of a concept's own attributes as extra refinements.
+  Works at the CF level — no string manipulation."
+  [st concept-id cf]
+  (let [full-cf (concept->cf st concept-id)
+        pick (fn [coll n] (when-let [s (seq coll)] (take (rand-int (inc (min (count s) n))) (shuffle s))))
+        extra-ungrouped (pick (:cf/ungrouped full-cf) 2)
+        extra-groups (pick (:cf/groups full-cf) 2)]
+    (cond-> cf
+      (seq extra-ungrouped) (update :cf/ungrouped (fnil into #{}) extra-ungrouped)
+      (seq extra-groups) (update :cf/groups (fnil into #{}) extra-groups))))
+
+(defn- generate-expression-pair
+  "Generate a random SCG expression pair from the test concept set."
+  [st]
+  (let [ids (vec test-concept-ids)
+        rand-id #(nth ids (rand-int (count ids)))
+        make (fn []
+               (let [cid (rand-id)
+                     cf (scg/ctu->cf (scg/str->ctu (str cid)))]
+                 (if (< (rand) 0.3)
+                   (render-cf (add-random-refinement st cid cf))
+                   (str cid))))]
+    [(make) (make)]))
+
+;;;; ── Test 1: Hand-written cases ──
+
+(def ^:private subsumption-oracle-cases
+  [{:description "concept subsumes itself"
+    :a "73211009" :b "73211009" :structural true}
+   {:description "parent subsumes child (demyelinating disease > MS)"
+    :a "6118003" :b "24700007" :structural true}
+   {:description "child does not subsume parent"
+    :a "24700007" :b "6118003" :structural false}
+   {:description "unrefined subsumes refined"
+    :a "71388002" :b "71388002 : 260686004 = 129304002" :structural true}
+   {:description "refined does not subsume unrefined"
+    :a "71388002 : 260686004 = 129304002" :b "71388002" :structural false}
+   {:description "more specific attribute value is subsumed"
+    :a "64572001 : 363698007 = 39607008" :b "64572001 : 363698007 = 181216001"
+    :structural true}
+   {:description "unrelated attribute values — no subsumption"
+    :a "64572001 : 363698007 = 39607008" :b "64572001 : 363698007 = 64033007"
+    :structural false}
+   {:description "fully-defined concept subsumes itself refined"
+    :a "80146002" :b "80146002 : 272741003 = 7771000" :structural true}
+   {:description "fewer group attrs subsumes more"
+    :a "71388002 : { 260686004 = 129304002 }"
+    :b "71388002 : { 260686004 = 129304002, 405813007 = 66754008 }"
+    :structural true}
+   {:description "two groups does not subsume one group"
+    :a "71388002 : { 260686004 = 129304002, 405813007 = 15497006 } { 260686004 = 129304002, 405813007 = 31435000 }"
+    :b "71388002 : { 260686004 = 129304002, 405813007 = 15497006 }"
+    :structural false}
+   {:description "identical expressions — mutual subsumption"
+    :a "80146002" :b "80146002" :structural true}
+   {:description "terms ignored"
+    :a "80146002 |Appendectomy|" :b "80146002" :structural true}])
+
+;;;; ── Test 2: Systematic concept-pair subsumption across hierarchies ──
+
+(def ^:private concept-pair-cases
+  "Systematic pairs testing IS-A hierarchy, cross-hierarchy, and refinement
+  patterns across multiple SNOMED hierarchies."
+  [;; IS-A hierarchy: parent/child
+   {:description "disease subsumes diabetes"
+    :a "64572001" :b "73211009" :structural true}
+   {:description "diabetes does not subsume disease"
+    :a "73211009" :b "64572001" :structural false}
+   {:description "clinical finding subsumes MS"
+    :a "404684003" :b "24700007" :structural true}
+   {:description "procedure subsumes appendectomy"
+    :a "71388002" :b "80146002" :structural true}
+   {:description "procedure subsumes oophorectomy"
+    :a "71388002" :b "83152002" :structural true}
+   {:description "procedure subsumes cholecystectomy"
+    :a "71388002" :b "38102005" :structural true}
+   {:description "appendectomy does not subsume procedure"
+    :a "80146002" :b "71388002" :structural false}
+
+   ;; Cross-hierarchy: unrelated concepts
+   {:description "procedure vs clinical finding — unrelated"
+    :a "71388002" :b "404684003" :structural false}
+   {:description "diabetes vs appendectomy — unrelated"
+    :a "73211009" :b "80146002" :structural false}
+   {:description "lung vs kidney — unrelated"
+    :a "39607008" :b "64033007" :structural false}
+   {:description "MS vs MI — unrelated findings"
+    :a "24700007" :b "22298006" :structural false}
+   {:description "oophorectomy vs cholecystectomy — unrelated procedures"
+    :a "83152002" :b "38102005" :structural false}
+   {:description "asthma vs pulmonary edema — unrelated findings"
+    :a "195967001" :b "19242006" :structural false}
+
+   ;; Body structure subsumption
+   {:description "lung subsumes entire lung"
+    :a "39607008" :b "181216001" :structural true}
+   {:description "entire lung does not subsume lung"
+    :a "181216001" :b "39607008" :structural false}
+
+   ;; Self-subsumption for various concepts
+   {:description "diabetes subsumes itself"
+    :a "73211009" :b "73211009" :structural true}
+   {:description "oophorectomy subsumes itself"
+    :a "83152002" :b "83152002" :structural true}
+   {:description "lung subsumes itself"
+    :a "39607008" :b "39607008" :structural true}
+
+   ;; Refinement patterns: same base with different sites/values
+   {:description "disease+lung subsumes disease+entire-lung"
+    :a "64572001 : 363698007 = 39607008"
+    :b "64572001 : 363698007 = 181216001"
+    :structural true}
+   {:description "disease+kidney does not subsume disease+lung"
+    :a "64572001 : 363698007 = 64033007"
+    :b "64572001 : 363698007 = 39607008"
+    :structural false}
+   {:description "procedure+method subsumes procedure+method+site (more refined)"
+    :a "71388002 : { 260686004 = 129304002 }"
+    :b "71388002 : { 260686004 = 129304002 , 405813007 = 15497006 }"
+    :structural true}
+   {:description "procedure+method+site does not subsume procedure+method"
+    :a "71388002 : { 260686004 = 129304002 , 405813007 = 15497006 }"
+    :b "71388002 : { 260686004 = 129304002 }"
+    :structural false}
+
+   ;; Laterality refinements
+   {:description "appendectomy subsumes appendectomy+left"
+    :a "80146002" :b "80146002 : 272741003 = 7771000" :structural true}
+   {:description "appendectomy+left does not subsume appendectomy"
+    :a "80146002 : 272741003 = 7771000" :b "80146002" :structural false}
+   {:description "appendectomy+left does not subsume appendectomy+right"
+    :a "80146002 : 272741003 = 7771000"
+    :b "80146002 : 272741003 = 24028007"
+    :structural false}
+   {:description "appendectomy+right does not subsume appendectomy+left"
+    :a "80146002 : 272741003 = 24028007"
+    :b "80146002 : 272741003 = 7771000"
+    :structural false}
+
+   ;; Procedure with different sites
+   {:description "procedure+ovary does not subsume procedure+fallopian-tube"
+    :a "71388002 : { 260686004 = 129304002 , 405813007 = 15497006 }"
+    :b "71388002 : { 260686004 = 129304002 , 405813007 = 31435000 }"
+    :structural false}
+
+   ;; Multiple groups
+   {:description "one group subsumes same concept with two groups (extra group)"
+    :a "71388002 : { 260686004 = 129304002 , 405813007 = 15497006 }"
+    :b "71388002 : { 260686004 = 129304002 , 405813007 = 15497006 } { 260686004 = 129304002 , 405813007 = 31435000 }"
+    :structural true}
+
+   ;; Parent concept subsumes child with refinement
+   {:description "procedure subsumes appendectomy+laterality"
+    :a "71388002" :b "80146002 : 272741003 = 7771000" :structural true}
+   {:description "disease subsumes disease+finding-site=lung"
+    :a "64572001" :b "64572001 : 363698007 = 39607008" :structural true}
+
+   ;; Fully-defined sibling concepts
+   {:description "appendectomy does not subsume oophorectomy"
+    :a "80146002" :b "83152002" :structural false}
+   {:description "oophorectomy does not subsume appendectomy"
+    :a "83152002" :b "80146002" :structural false}])
+
+;;;; ── Test 3: Generated refinement pairs ──
+
+(defn- generate-refinement-pairs
+  "Generate subsumption pairs from real concept properties using the SCG pipeline.
+  For each concept, tests: base subsumes base+extra-attr (and the converse)."
+  [st]
+  (let [concepts [80146002 83152002 73211009 24700007 22298006]]
+    (mapcat
+      (fn [cid]
+        (let [cf (concept->cf st cid)
+              base (str cid)
+              ungrouped (seq (:cf/ungrouped cf))
+              groups (seq (:cf/groups cf))]
+          (concat
+            ;; Base subsumes base + single ungrouped attr
+            (for [attr (take 3 ungrouped)
+                  :let [refined-cf (update cf :cf/ungrouped (fnil conj #{}) attr)
+                        refined-str (render-cf refined-cf)]]
+              {:description (str cid " subsumes " cid " + ungrouped attr")
+               :a base :b refined-str :structural true})
+            ;; Base + single ungrouped attr does not subsume base
+            (for [attr (take 3 ungrouped)
+                  :let [refined-cf (update cf :cf/ungrouped (fnil conj #{}) attr)
+                        refined-str (render-cf refined-cf)]]
+              {:description (str cid " + ungrouped attr does not subsume " cid)
+               :a refined-str :b base :structural false})
+            ;; Base subsumes base + single group
+            (for [g (take 2 groups)
+                  :let [refined-cf (update cf :cf/groups (fnil conj #{}) g)
+                        refined-str (render-cf refined-cf)]]
+              {:description (str cid " subsumes " cid " + group")
+               :a base :b refined-str :structural true}))))
+      concepts)))
+
+;;;; ── Test runners ──
+
+(deftest ^:live oracle-hand-written-cases
+  (doseq [{:keys [description a b structural]} subsumption-oracle-cases]
+    (testing description
+      (is (= structural (owl-subsumes? *reasoner* a b))
+          (str "OWL disagrees with expected: " structural)))))
+
+(deftest ^:live oracle-concept-pairs
+  (doseq [{:keys [description a b structural]} concept-pair-cases]
+    (testing description
+      (is (= structural (owl-subsumes? *reasoner* a b))
+          (str "OWL disagrees — expected: " structural)))))
+
+(deftest ^:live oracle-generated-refinements
+  (let [pairs (generate-refinement-pairs *store*)]
+    (println "  Testing" (count pairs) "generated refinement pairs")
+    (doseq [{:keys [description a b structural]} pairs]
+      (testing description
+        (is (= structural (owl-subsumes? *reasoner* a b))
+            (str "OWL disagrees — expected: " structural))))))
+
+(deftest ^:live oracle-random-agreement
+  (let [pairs (repeatedly 200 #(generate-expression-pair *store*))
+        results (mapv (fn [[a b]] (check-oracle-agreement *store* *reasoner* a b)) pairs)
+        agreements (count (filter :agree? results))
+        disagreements (remove :agree? results)
+        total (count results)
+        pct (if (pos? total) (* 100.0 (/ agreements total)) 100.0)]
+    (println (format "  Oracle agreement: %d/%d (%.1f%%)" agreements total pct))
+    (when (seq disagreements)
+      (println "  Disagreements (may be GCI gaps):")
+      (doseq [{:keys [a b structural owl]} (take 10 disagreements)]
+        (println (str "    " a (if structural " ⊒ " " ⋢ ") b
+                      " — structural:" structural " owl:" owl))))
+    (is (> (/ (double agreements) total) 0.90)
+        (str "Agreement rate " (format "%.1f%%" pct) " is below 90% threshold"))))
+
+;;;; ── Equivalence discovery ──
+
+(deftest ^:live oracle-equivalence-discovery
+  (testing "fully-defined concept equivalent to itself via ctu->cf"
+    (let [cf (scg/ctu->cf (scg/str->ctu "80146002"))
+          result (owl/classify *reasoner* cf)]
+      (is (contains? (::owl/equivalent-concepts result) 80146002))))
+
+  (testing "normalized form loses equivalence but gains superclass"
+    (let [cf (scg/ctu->cf+normalize *store* (scg/str->ctu "80146002"))
+          result (owl/classify *reasoner* cf)]
+      (is (not (contains? (::owl/equivalent-concepts result) 80146002)))
+      (is (contains? (::owl/direct-super-concepts result) 80146002))))
+
+  (testing "post-coordinated expression classified under base concept"
+    (let [cf (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000"))
+          result (owl/classify *reasoner* cf)]
+      (is (contains? (::owl/direct-super-concepts result) 80146002)))))
+
+;;;; ── Normalize validation via classification ──
+
+(deftest ^:live oracle-normalize-preserves-semantics
+  (doseq [expr-str ["80146002"
+                     "73211009"
+                     "80146002 : 272741003 = 7771000"
+                     "64572001 : 363698007 = 39607008"
+                     "83152002"
+                     "22298006"
+                     "24700007"
+                     "38102005"]]
+    (testing (str "normalize preserves semantics: " expr-str)
+      (let [parsed      (scg/str->ctu expr-str)
+            ctu-cf      (scg/ctu->cf parsed)
+            norm-cf     (scg/ctu->cf+normalize *store* parsed)
+            ctu-result  (owl/classify *reasoner* ctu-cf)
+            norm-result (owl/classify *reasoner* norm-cf)]
+        (is (or (seq (::owl/equivalent-concepts ctu-result))
+                (seq (::owl/direct-super-concepts ctu-result)))
+            "ctu->cf form should classify")
+        (is (or (seq (::owl/equivalent-concepts norm-result))
+                (seq (::owl/direct-super-concepts norm-result)))
+            "normalized form should classify")))))
+
+;;;; ── NNF semantic validation ──
+
+(deftest ^:live oracle-nnf-semantic-correctness
+  (testing "NNF is semantically equivalent to original expression"
+    (doseq [expr-str ["80146002"
+                       "80146002 : 272741003 = 7771000"
+                       "83152002"]]
+      (testing (str "NNF equivalence: " expr-str)
+        (let [cf      (scg/ctu->cf (scg/str->ctu expr-str))
+              nnf     (owl/necessary-normal-form *reasoner* cf)
+              fwd     (owl/subsumes? *reasoner* cf nnf)
+              nnf-eq  (assoc nnf :cf/definition-status :equivalent-to)
+              rev     (owl/subsumes? *reasoner* nnf-eq cf)]
+          (is (contains? #{:equivalent :subsumes} fwd)
+              (str "original should subsume NNF (NNF at least as specific). Got: " fwd
+                   "\nNNF: " (pr-str nnf)))
+          (is (contains? #{:equivalent :subsumes} rev)
+              (str "NNF (as equiv) should subsume original (NNF at least as general). Got: " rev
+                   "\nNNF: " (pr-str nnf)))))))
+  (testing "NNF contains inherited relationships"
+    (let [cf  (scg/ctu->cf (scg/str->ctu "80146002"))
+          nnf (owl/necessary-normal-form *reasoner* cf)]
+      (is (seq (:cf/groups nnf))
+          "appendectomy NNF should have inherited groups")))
+  (testing "NNF preserves user refinements alongside inherited"
+    (let [cf  (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000"))
+          nnf (owl/necessary-normal-form *reasoner* cf)]
+      (is (contains? (:cf/ungrouped nnf) [272741003 [:concept 7771000]])
+          "laterality should be in NNF")
+      (is (seq (:cf/groups nnf))
+          "inherited groups should also be present"))))
+
+;;;; ── Bidirectional subsumption agreement ──
+
+(deftest ^:live oracle-subsumption-symmetry
+  (testing "mutual subsumption = equivalence"
+    (let [cf (scg/ctu->cf (scg/str->ctu "80146002"))]
+      (is (= :equivalent (owl/subsumes? *reasoner* cf cf)))))
+
+  (testing "asymmetric subsumption is consistent"
+    (let [base    (scg/ctu->cf (scg/str->ctu "80146002"))
+          refined (scg/ctu->cf (scg/str->ctu "80146002 : 272741003 = 7771000"))]
+      (is (= :subsumes (owl/subsumes? *reasoner* base refined)))
+      (is (= :subsumed-by (owl/subsumes? *reasoner* refined base)))))
+
+  (testing "unrelated concepts are not-subsumed in both directions"
+    (doseq [[a b] [["80146002" "22298006"]
+                    ["73211009" "83152002"]
+                    ["39607008" "64033007"]
+                    ["24700007" "38102005"]]]
+      (let [a-cf (scg/ctu->cf (scg/str->ctu a))
+            b-cf (scg/ctu->cf (scg/str->ctu b))]
+        (is (= :not-subsumed (owl/subsumes? *reasoner* a-cf b-cf))
+            (str a " vs " b))
+        (is (= :not-subsumed (owl/subsumes? *reasoner* b-cf a-cf))
+            (str b " vs " a))))))

--- a/test/src/com/eldrix/hermes/owl_test.clj
+++ b/test/src/com/eldrix/hermes/owl_test.clj
@@ -1,6 +1,7 @@
 (ns com.eldrix.hermes.owl-test
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
+            [clojure.spec.test.alpha :as stest]
             [clojure.test :refer [deftest is testing]]
             [com.eldrix.hermes.impl.owl :as owl]
             [com.eldrix.hermes.impl.scg :as scg])
@@ -8,9 +9,7 @@
            (org.semanticweb.owlapi.model OWLEquivalentClassesAxiom OWLSubClassOfAxiom)
            (org.semanticweb.owlapi.util DefaultPrefixManager)))
 
-(def ^:private manager (OWLManager/createOWLOntologyManager))
-(def ^:private factory (.getOWLDataFactory manager))
-(def ^:private pm (doto (DefaultPrefixManager.) (.setDefaultPrefix "http://snomed.info/id/")))
+(stest/instrument)
 
 (def ^:private test-cases
   [{:description "Simple IS-A (primitive, single focus concept)"
@@ -79,7 +78,10 @@
     :expected    ["EquivalentClasses(" ":404684003" ":138875005"]}])
 
 (deftest run-test-cases
-  (let [parse (owl/create-axiom-deserializer)]
+  (let [manager (OWLManager/createOWLOntologyManager)
+        factory (.getOWLDataFactory manager)
+        pm      (doto (DefaultPrefixManager.) (.setDefaultPrefix "http://snomed.info/id/"))
+        parse   (owl/create-axiom-deserializer)]
     (doseq [{:keys [description concept-id cf expected]} test-cases]
       (testing description
         (let [axiom   (owl/cf->axiom factory pm concept-id cf)
@@ -97,7 +99,10 @@
                   (str "Expected " fragment " in: " owl-str)))))))))
 
 (deftest generative-properties
-  (let [parse (owl/create-axiom-deserializer)]
+  (let [manager (OWLManager/createOWLOntologyManager)
+        factory (.getOWLDataFactory manager)
+        pm      (doto (DefaultPrefixManager.) (.setDefaultPrefix "http://snomed.info/id/"))
+        parse   (owl/create-axiom-deserializer)]
     (doseq [[cf-expr concept-id] (map vector
                                       (gen/sample (s/gen :cf/expression) 100)
                                       (gen/sample (s/gen :info.snomed.Concept/id) 100))]

--- a/test/src/com/eldrix/hermes/owl_test.clj
+++ b/test/src/com/eldrix/hermes/owl_test.clj
@@ -1,0 +1,312 @@
+(ns com.eldrix.hermes.owl-test
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.test :refer [deftest is testing]]
+            [com.eldrix.hermes.impl.owl :as owl]
+            [com.eldrix.hermes.impl.scg :as scg])
+  (:import (org.semanticweb.owlapi.apibinding OWLManager)
+           (org.semanticweb.owlapi.model OWLEquivalentClassesAxiom OWLSubClassOfAxiom)
+           (org.semanticweb.owlapi.util DefaultPrefixManager)))
+
+(def ^:private manager (OWLManager/createOWLOntologyManager))
+(def ^:private factory (.getOWLDataFactory manager))
+(def ^:private pm (doto (DefaultPrefixManager.) (.setDefaultPrefix "http://snomed.info/id/")))
+
+(def ^:private test-cases
+  [{:description "Simple IS-A (primitive, single focus concept)"
+    :concept-id  118956008
+    :cf          {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{123037004}}
+    :expected    "SubClassOf(:118956008 :123037004)"}
+
+   {:description "Equivalent with two grouped relationships"
+    :concept-id  10002003
+    :cf          {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{116175006}
+                  :cf/groups            #{#{[260686004 [:concept 129304002]]
+                                            [405813007 [:concept 414003]]}}}
+    :expected    "EquivalentClasses(:10002003 ObjectIntersectionOf(:116175006 ObjectSomeValuesFrom(:609096000 ObjectIntersectionOf(ObjectSomeValuesFrom(:260686004 :129304002) ObjectSomeValuesFrom(:405813007 :414003)))))"}
+
+   {:description "Primitive with single-attribute group"
+    :concept-id  8801005
+    :cf          {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{73211009}
+                  :cf/groups            #{#{[100105001 [:concept 100101001]]}}}
+    :expected    "SubClassOf(:8801005 ObjectIntersectionOf(:73211009 ObjectSomeValuesFrom(:609096000 ObjectSomeValuesFrom(:100105001 :100101001))))"}
+
+   {:description "Equivalent with multiple focus concepts and ungrouped attribute"
+    :concept-id  9846003
+    :cf          {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{39132006 64033007}
+                  :cf/ungrouped         #{[272741003 [:concept 24028007]]}}
+    :expected    "EquivalentClasses(:9846003 ObjectIntersectionOf(:39132006 :64033007 ObjectSomeValuesFrom(:272741003 :24028007)))"}
+
+   {:description "Simple IS-A with no attributes"
+    :concept-id  404684003
+    :cf          {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{138875005}}
+    :expected    "SubClassOf(:404684003 :138875005)"}
+
+   {:description "Equivalent with concrete numeric value (DataHasValue)"
+    :concept-id  322236009
+    :cf          {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{763158003}
+                  :cf/ungrouped         #{[411116001 [:concept 421026006]]
+                                          [763032000 [:concept 732936001]]
+                                          [3264479001 [:numeric 1]]}}
+    :expected    ["DataHasValue(:3264479001" ":322236009"]}
+
+   {:description "Equivalent with multiple groups"
+    :concept-id  71388002
+    :cf          {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{128927009}
+                  :cf/groups            #{#{[260686004 [:concept 129304002]]
+                                            [405813007 [:concept 15497006]]}
+                                         #{[260686004 [:concept 129304002]]
+                                            [405813007 [:concept 31435000]]}}}
+    :expected    [":71388002" ":128927009" ":15497006" ":31435000"]}
+
+   {:description "Single focus concept, no attributes"
+    :concept-id  999999
+    :cf          {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{404684003}}
+    :expected    "SubClassOf(:999999 :404684003)"}
+
+   {:description "Multiple focus concepts, no groups or ungrouped"
+    :concept-id  999999
+    :cf          {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{404684003 138875005}}
+    :expected    ["EquivalentClasses(" ":404684003" ":138875005"]}])
+
+(deftest run-test-cases
+  (let [parse (owl/create-axiom-deserializer)]
+    (doseq [{:keys [description concept-id cf expected]} test-cases]
+      (testing description
+        (let [axiom   (owl/cf->axiom factory pm concept-id cf)
+              owl-str (owl/axiom->owl-string axiom)]
+          (if (= :subtype-of (:cf/definition-status cf))
+            (is (instance? OWLSubClassOfAxiom axiom))
+            (is (instance? OWLEquivalentClassesAxiom axiom)))
+          (cond
+            (string? expected)
+            (is (= (parse expected) axiom)
+                (str "Expected: " expected "\nGot: " owl-str))
+            (vector? expected)
+            (doseq [fragment expected]
+              (is (.contains owl-str fragment)
+                  (str "Expected " fragment " in: " owl-str)))))))))
+
+(deftest generative-properties
+  (let [parse (owl/create-axiom-deserializer)]
+    (doseq [[cf-expr concept-id] (map vector
+                                      (gen/sample (s/gen :cf/expression) 100)
+                                      (gen/sample (s/gen :info.snomed.Concept/id) 100))]
+      (let [axiom (owl/cf->axiom factory pm concept-id cf-expr)
+            owl-s (owl/axiom->owl-string axiom)]
+        (if (= :subtype-of (:cf/definition-status cf-expr))
+          (is (instance? OWLSubClassOfAxiom axiom))
+          (is (instance? OWLEquivalentClassesAxiom axiom)))
+        (is (or (.startsWith owl-s "SubClassOf(")
+                (.startsWith owl-s "EquivalentClasses(")))
+        (is (.contains owl-s (str ":" concept-id)))
+        (is (zero? (reduce (fn [depth c]
+                             (case c \( (inc depth) \) (dec depth) depth))
+                           0 owl-s)))
+        (is (= axiom (parse owl-s))
+            (str "Round-trip failed for: " owl-s))))))
+
+;;;; ── Error cases ──
+
+(deftest deserialize-axiom-errors
+  (let [parse (owl/create-axiom-deserializer)]
+    (testing "garbage input throws"
+      (is (thrown? Exception (parse "this is not OWL"))))
+    (testing "empty string throws"
+      (is (thrown? Exception (parse ""))))
+    (testing "annotation axiom is parsed correctly"
+      (is (some? (parse "SubAnnotationPropertyOf(:1295449009 :1295447006)"))))))
+
+;;;; ── ECL generation ──
+
+(deftest cf->ecl*-simple-concept
+  (testing "single focus concept, no attributes"
+    (is (= "<< 404684003"
+           (owl/cf->ecl* {:cf/definition-status :subtype-of
+                           :cf/focus-concepts    #{404684003}}))))
+  (testing "multiple focus concepts"
+    (is (= "(<< 138875005 AND << 404684003)"
+           (owl/cf->ecl* {:cf/definition-status :equivalent-to
+                           :cf/focus-concepts    #{404684003 138875005}})))))
+
+(deftest cf->ecl*-with-refinements
+  (testing "ungrouped attribute"
+    (is (= "<< 80146002 : 272741003 = << 7771000"
+           (owl/cf->ecl* {:cf/definition-status :equivalent-to
+                           :cf/focus-concepts    #{80146002}
+                           :cf/ungrouped         #{[272741003 [:concept 7771000]]}}))))
+  (testing "grouped attributes"
+    (let [ecl (owl/cf->ecl* {:cf/definition-status :equivalent-to
+                              :cf/focus-concepts    #{128927009}
+                              :cf/groups            #{#{[260686004 [:concept 129304002]]
+                                                        [405813007 [:concept 15497006]]}}})]
+      (is (.startsWith ecl "<< 128927009 : { "))
+      (is (.contains ecl "260686004 = << 129304002"))
+      (is (.contains ecl "405813007 = << 15497006"))))
+  (testing "concrete numeric value"
+    (is (= "<< 763158003 : 3264479001 = #1"
+           (owl/cf->ecl* {:cf/definition-status :equivalent-to
+                           :cf/focus-concepts    #{763158003}
+                           :cf/ungrouped         #{[3264479001 [:numeric 1]]}})))))
+
+;;;; ── compute-nnf (pure — no store or reasoner needed) ──
+
+(def ^:private compute-nnf-cases
+  "Declarative test cases for compute-nnf. Each case specifies the inputs and
+  expected outputs. reduce-attrs-fn, reduce-groups-fn, property-chains,
+  rel-targets-fn, and is-a-fn default to identity/empty when not specified."
+  [{:description "merges inherited + user attributes"
+    :pps-ids     #{71388002 118698009}
+    :cf-expr     {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{80146002}
+                  :cf/ungrouped         #{[272741003 [:concept 7771000]]}}
+    :inherited   {:ungrouped #{}
+                  :groups    #{#{[260686004 [:concept 129304002]]
+                                [405813007 [:concept 66754008]]}}}
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{71388002 118698009}
+                  :cf/ungrouped         #{[272741003 [:concept 7771000]]}
+                  :cf/groups            #{#{[260686004 [:concept 129304002]]
+                                           [405813007 [:concept 66754008]]}}}}
+
+   {:description "no inherited, no user refinements — bare focus concepts"
+    :pps-ids     #{404684003}
+    :cf-expr     {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{404684003}}
+    :inherited   {:ungrouped #{} :groups #{}}
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{404684003}}}
+
+   {:description "unknown focus concepts — only user refinements survive"
+    :pps-ids     #{999999}
+    :cf-expr     {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{888888}
+                  :cf/ungrouped         #{[272741003 [:concept 7771000]]}
+                  :cf/groups            #{#{[260686004 [:concept 129304002]]}}}
+    :inherited   {:ungrouped #{} :groups #{}}
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{999999}
+                  :cf/ungrouped         #{[272741003 [:concept 7771000]]}
+                  :cf/groups            #{#{[260686004 [:concept 129304002]]}}}}
+
+   {:description "unknown focus + no user refinements — bare NNF"
+    :pps-ids     #{999999}
+    :cf-expr     {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{888888}}
+    :inherited   {:ungrouped #{} :groups #{}}
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{999999}}}
+
+   {:description "mixed known/unknown focus — inherited from known only"
+    :pps-ids     #{111 222}
+    :cf-expr     {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{111 888888}
+                  :cf/ungrouped         #{[300 [:concept 400]]}}
+    :inherited   {:ungrouped #{[500 [:concept 600]]}
+                  :groups    #{}}
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{111 222}
+                  :cf/ungrouped         #{[300 [:concept 400]] [500 [:concept 600]]}}}])
+
+(def ^:private compute-nnf-reduce-cases
+  "Cases testing reduce-attrs-fn and reduce-groups-fn application."
+  [{:description "reduce-attrs-fn applied to ungrouped and each group"
+    :pps-ids     #{1}
+    :cf-expr     {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}
+                  :cf/ungrouped         #{[999 [:concept 2]] [100 [:concept 3]]}}
+    :inherited   {:ungrouped #{} :groups #{#{[999 [:concept 4]] [200 [:concept 5]]}}}
+    :reduce-attrs (fn [attrs] (into #{} (remove #(= 999 (first %))) attrs))
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}
+                  :cf/ungrouped         #{[100 [:concept 3]]}
+                  :cf/groups            #{#{[200 [:concept 5]]}}}}
+
+   {:description "reduce-groups-fn applied after per-group reduction"
+    :pps-ids     #{1}
+    :cf-expr     {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}}
+    :inherited   {:ungrouped #{}
+                  :groups    #{#{[200 [:concept 5]]}
+                              #{[300 [:concept 6]]}}}
+    :reduce-groups (fn [groups]
+                     (into #{} (remove #(some (fn [[t]] (= 200 t)) %)) groups))
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}
+                  :cf/groups            #{#{[300 [:concept 6]]}}}}])
+
+(def ^:private compute-nnf-chain-cases
+  "Cases testing property chain redundancy removal."
+  [{:description "chain removes redundant attribute from group"
+    :pps-ids     #{1}
+    :cf-expr     {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}}
+    :inherited   {:ungrouped #{} :groups #{#{[200 [:concept 50]] [100 [:concept 60]]}}}
+    :chains      {100 #{[200 300]}}
+    :rel-targets      (fn [cid tid] (if (and (= cid 50) (= tid 300)) #{60} #{}))
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}
+                  :cf/groups            #{#{[200 [:concept 50]]}}}}
+
+   {:description "no chains — groups untouched"
+    :pps-ids     #{1}
+    :cf-expr     {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}}
+    :inherited   {:ungrouped #{} :groups #{#{[200 [:concept 50]] [100 [:concept 60]]}}}
+    :chains      {}
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}
+                  :cf/groups            #{#{[200 [:concept 50]] [100 [:concept 60]]}}}}
+
+   {:description "chain with is-a: value-id is-a target triggers redundancy"
+    :pps-ids     #{1}
+    :cf-expr     {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}}
+    :inherited   {:ungrouped #{} :groups #{#{[200 [:concept 50]] [100 [:concept 60]]}}}
+    :chains      {100 #{[200 300]}}
+    :rel-targets      (fn [cid tid] (if (and (= cid 50) (= tid 300)) #{70} #{}))
+    :is-a?     (fn [child parent] (and (= child 60) (= parent 70)))
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}
+                  :cf/groups            #{#{[200 [:concept 50]]}}}}
+
+   {:description "non-concept values unaffected by chains"
+    :pps-ids     #{1}
+    :cf-expr     {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}}
+    :inherited   {:ungrouped #{} :groups #{#{[200 [:concept 50]] [100 [:numeric 42]]}}}
+    :chains      {100 #{[200 300]}}
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{1}
+                  :cf/groups            #{#{[200 [:concept 50]] [100 [:numeric 42]]}}}}])
+
+(defn- run-compute-nnf-case
+  [{:keys [description pps-ids cf-expr inherited expected] :as tc}]
+  (testing description
+    (let [nnf (owl/compute-nnf pps-ids cf-expr inherited tc)]
+      (is (= (:cf/definition-status expected) (:cf/definition-status nnf)))
+      (is (= (:cf/focus-concepts expected) (:cf/focus-concepts nnf)))
+      (is (= (:cf/ungrouped expected) (:cf/ungrouped nnf)))
+      (is (= (:cf/groups expected) (:cf/groups nnf))))))
+
+(deftest compute-nnf-merge-and-assembly
+  (doseq [tc compute-nnf-cases]
+    (run-compute-nnf-case tc)))
+
+(deftest compute-nnf-reduce-fns
+  (doseq [tc compute-nnf-reduce-cases]
+    (run-compute-nnf-case tc)))
+
+(deftest compute-nnf-chain-redundancy
+  (doseq [tc compute-nnf-chain-cases]
+    (run-compute-nnf-case tc)))
+

--- a/test/src/com/eldrix/hermes/scg_test.clj
+++ b/test/src/com/eldrix/hermes/scg_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.test :refer [deftest is testing run-tests]]
             [com.eldrix.hermes.impl.scg :as scg]
-            [com.eldrix.hermes.impl.store :as store]))
+            [com.eldrix.hermes.impl.store :as store]
+            [com.eldrix.hermes.snomed :as snomed]))
 
 (def test-cases
   [{:description "Simple concept ID without term"
@@ -718,6 +719,80 @@
     (doseq [s ["xxxx" "not a concept" "!!!" "" "abc123" ": = 1234"]]
       (is (thrown? Exception (scg/str->ctu s))
           (str "Expected exception for invalid expression: " (pr-str s))))))
+
+(defn- find-same-as-concept
+  "Find an inactive concept with a SAME_AS association pointing to an active
+  concept by searching backwards from a known active concept (24700007)."
+  [st]
+  (when-let [inactive-id (first (store/source-historical st 24700007 [snomed/SameAsReferenceSet]))]
+    {:inactive-id inactive-id :active-id 24700007}))
+
+(deftest ^:live replace-historical-active-unchanged
+  (with-open [st (store/open-store "snomed.db/store.db")]
+    (testing "Active concepts are not replaced"
+      (let [expr (scg/str->ctu "24700007")]
+        (is (= expr (scg/replace-historical st expr)))))
+    (testing "Active concepts with refinements are not replaced"
+      (let [expr (scg/str->ctu "73211009 : 363698007 = 113331007")]
+        (is (= expr (scg/replace-historical st expr)))))
+    (testing "Active concepts with groups are not replaced"
+      (let [expr (scg/str->ctu "71388002 : { 260686004 = 129304002 , 405813007 = 15497006 }")]
+        (is (= expr (scg/replace-historical st expr)))))
+    (testing "Non-existent concept is not replaced"
+      (let [expr (scg/str->ctu "100000102")]
+        (is (= expr (scg/replace-historical st expr)))))))
+
+(deftest ^:live replace-historical-inactive-focus
+  (with-open [st (store/open-store "snomed.db/store.db")]
+    (when-let [{:keys [inactive-id active-id]} (find-same-as-concept st)]
+      (testing "Inactive focus concept with SAME_AS is replaced"
+        (let [expr (scg/str->ctu (str inactive-id))
+              result (scg/replace-historical st expr)]
+          (is (= active-id (get-in result [:subExpression :focusConcepts 0 :conceptId])))
+          (is (s/valid? :ctu/expression result))))
+      (testing "Replaced expression can be normalized"
+        (let [expr (scg/str->ctu (str inactive-id))
+              result (-> (scg/replace-historical st expr)
+                         (->> (scg/ctu->cf+normalize st)))]
+          (is (s/valid? :cf/expression result))))
+      (testing "Inactive focus with refinement — focus replaced, refinement preserved"
+        (let [expr (scg/str->ctu (str inactive-id " : 272741003 = 7771000"))
+              result (scg/replace-historical st expr)]
+          (is (= active-id (get-in result [:subExpression :focusConcepts 0 :conceptId])))
+          (is (= [{:conceptId 272741003} {:conceptId 7771000}]
+                 (first (get-in result [:subExpression :refinements]))))))
+      (testing "Terms are dropped on replacement"
+        (let [expr (scg/str->ctu (str inactive-id " |old term|"))
+              result (scg/replace-historical st expr)]
+          (is (= active-id (get-in result [:subExpression :focusConcepts 0 :conceptId])))
+          (is (nil? (:term (get-in result [:subExpression :focusConcepts 0])))))))))
+
+(deftest ^:live replace-historical-inactive-attribute
+  (with-open [st (store/open-store "snomed.db/store.db")]
+    (when-let [{:keys [inactive-id active-id]} (find-same-as-concept st)]
+      (testing "Inactive concept in attribute value position is replaced"
+        (let [expr (scg/str->ctu (str "73211009 : 363698007 = " inactive-id))
+              result (scg/replace-historical st expr)]
+          (is (= active-id (:conceptId (second (first (get-in result [:subExpression :refinements]))))))))
+      (testing "Inactive concept in grouped attribute value is replaced"
+        (let [expr (scg/str->ctu (str "71388002 : { 260686004 = 129304002 , 363698007 = " inactive-id " }"))
+              result (scg/replace-historical st expr)
+              group (first (get-in result [:subExpression :refinements]))]
+          (is (set? group))
+          (is (some #(= active-id (:conceptId (second %))) group))))
+      (testing "Inactive concept in nested expression is replaced"
+        (let [expr (scg/str->ctu (str "243796009 : 246090004 = ( " inactive-id " )"))
+              result (scg/replace-historical st expr)
+              nested (second (first (get-in result [:subExpression :refinements])))]
+          (is (= active-id (get-in nested [:focusConcepts 0 :conceptId]))))))))
+
+(deftest ^:live replace-historical-profiles
+  (with-open [st (store/open-store "snomed.db/store.db")]
+    (testing "Active expression unchanged across all profiles"
+      (let [expr (scg/str->ctu "24700007")]
+        (is (= expr (scg/replace-historical st expr :profile :HISTORY-MIN)))
+        (is (= expr (scg/replace-historical st expr :profile :HISTORY-MOD)))
+        (is (= expr (scg/replace-historical st expr :profile :HISTORY-MAX)))))))
 
 (comment
   (run-tests))

--- a/test/src/com/eldrix/hermes/scg_test.clj
+++ b/test/src/com/eldrix/hermes/scg_test.clj
@@ -60,7 +60,7 @@
     :expression  "774586009 |Amoxicillin| : 189999999103 |Has strength value| = #500"
     :parsed      {:definitionStatus :equivalent-to
                   :subExpression    {:focusConcepts [{:conceptId 774586009 :term "Amoxicillin"}]
-                                     :refinements   [[{:conceptId 189999999103 :term "Has strength value"} 500]]}}}
+                                     :refinements   [[{:conceptId 189999999103 :term "Has strength value"} 500.0]]}}}
 
    {:description "Numeric (decimal) concrete value"
     :expression  "91143003 |Albuterol| : 189999999103 |Has strength value| = #0.083"
@@ -116,7 +116,7 @@
                                                      #{[{:conceptId 127489000 :term "Has active ingredient"}
                                                         {:conceptId 372687004 :term "Amoxicillin"}]
                                                        [{:conceptId 189999999103 :term "Has strength value"}
-                                                        500]}]}}}
+                                                        500.0]}]}}}
 
    {:description "Multiple focus concepts with shared refinement"
     :expression  "119189000 |Ulna part| + 312845000 |Epiphysis of upper limb| : 272741003 |Laterality| = 7771000 |Left|"
@@ -186,7 +186,7 @@
                                                        [{:conceptId 179999999100 :term "Has basis of strength"}
                                                         {:conceptId 372687004 :term "Amoxicillin"}]
                                                        [{:conceptId 189999999103 :term "Has strength value"}
-                                                        500]
+                                                        500.0]
                                                        [{:conceptId 199999999101 :term "Has strength unit"}
                                                         {:conceptId 258684004 :term "mg"}]}]}}}
 
@@ -203,7 +203,7 @@
     :expression  "774586009 |Amoxicillin| : 189999999103 |Has strength value| = #-10"
     :parsed      {:definitionStatus :equivalent-to
                   :subExpression    {:focusConcepts [{:conceptId 774586009 :term "Amoxicillin"}]
-                                     :refinements   [[{:conceptId 189999999103 :term "Has strength value"} -10]]}}}
+                                     :refinements   [[{:conceptId 189999999103 :term "Has strength value"} -10.0]]}}}
 
    {:description "String value with escaped quote"
     :expression  "322236009 |Paracetamol 500mg tablet| : 209999999104 |Has trade name| = \"PAN\\\"ADOL\""
@@ -260,7 +260,7 @@
     :live        true
     :parsed      {:definitionStatus :equivalent-to
                   :subExpression    {:focusConcepts [{:conceptId 100000102}]}}
-    :errors      [{:type :concept-not-found :conceptId 100000102 :role :focus-concept}]}
+    :invalid     {:conceptId 100000102 :role :focus-concept}}
 
    {:description "Non-existent attribute type"
     :expression  "73211009 : 100000102 = 7771000"
@@ -268,7 +268,7 @@
     :parsed      {:definitionStatus :equivalent-to
                   :subExpression    {:focusConcepts [{:conceptId 73211009}]
                                      :refinements   [[{:conceptId 100000102} {:conceptId 7771000}]]}}
-    :errors      [{:type :concept-not-found :conceptId 100000102 :role :attribute-type}]}
+    :invalid     {:conceptId 100000102 :role :attribute-type}}
 
    {:description "Non-existent attribute value"
     :expression  "73211009 : 272741003 = 100000102"
@@ -276,16 +276,15 @@
     :parsed      {:definitionStatus :equivalent-to
                   :subExpression    {:focusConcepts [{:conceptId 73211009}]
                                      :refinements   [[{:conceptId 272741003} {:conceptId 100000102}]]}}
-    :errors      [{:type :concept-not-found :conceptId 100000102 :role :attribute-value}]}
+    :invalid     {:conceptId 100000102 :role :attribute-value}}
 
-   {:description "Multiple errors — bad focus and bad value"
+   {:description "Non-existent focus and value — throws on first"
     :expression  "100000102 : 272741003 = 100000102"
     :live        true
     :parsed      {:definitionStatus :equivalent-to
                   :subExpression    {:focusConcepts [{:conceptId 100000102}]
                                      :refinements   [[{:conceptId 272741003} {:conceptId 100000102}]]}}
-    :errors      [{:type :concept-not-found :conceptId 100000102 :role :focus-concept}
-                  {:type :concept-not-found :conceptId 100000102 :role :attribute-value}]}
+    :invalid     {:conceptId 100000102 :role :focus-concept}}
 
    {:description "Valid grouped attributes"
     :expression  "80146002 : { 260686004 = 129304002 , 405813007 = 66754008 }"
@@ -302,7 +301,7 @@
                   :subExpression    {:focusConcepts [{:conceptId 73211009}]}}
     :normalized  {:cf/definition-status :subtype-of
                   :cf/focus-concepts    #{73211009}
-                  :cf/groups           #{#{[363698007 113331007]}}}}
+                  :cf/groups           #{#{[363698007 [:concept 113331007]]}}}}
 
    {:description "Fully-defined concept — normalize expands to proximal primitives"
     :expression  "80146002"
@@ -311,8 +310,8 @@
                   :subExpression    {:focusConcepts [{:conceptId 80146002}]}}
     :normalized  {:cf/definition-status :subtype-of
                   :cf/focus-concepts    #{71388002 118698009 387713003}
-                  :cf/groups           #{#{[260686004 129304002]
-                                          [405813007 66754008]}}}}
+                  :cf/groups           #{#{[260686004 [:concept 129304002]]
+                                          [405813007 [:concept 66754008]]}}}}
 
    {:description "Post-coordinated — user refinement merged with defining attrs"
     :expression  "80146002 : 272741003 = 7771000"
@@ -322,9 +321,9 @@
                                      :refinements   [[{:conceptId 272741003} {:conceptId 7771000}]]}}
     :normalized  {:cf/definition-status :subtype-of
                   :cf/focus-concepts    #{71388002 118698009 387713003}
-                  :cf/ungrouped        #{[272741003 7771000]}
-                  :cf/groups           #{#{[260686004 129304002]
-                                          [405813007 66754008]}}}}
+                  :cf/ungrouped        #{[272741003 [:concept 7771000]]}
+                  :cf/groups           #{#{[260686004 [:concept 129304002]]
+                                          [405813007 [:concept 66754008]]}}}}
 
    {:description "Primitive with user refinement — own attrs included"
     :expression  "73211009 : 272741003 = 7771000"
@@ -334,8 +333,8 @@
                                      :refinements   [[{:conceptId 272741003} {:conceptId 7771000}]]}}
     :normalized  {:cf/definition-status :subtype-of
                   :cf/focus-concepts    #{73211009}
-                  :cf/ungrouped        #{[272741003 7771000]}
-                  :cf/groups           #{#{[363698007 113331007]}}}}
+                  :cf/ungrouped        #{[272741003 [:concept 7771000]]}
+                  :cf/groups           #{#{[363698007 [:concept 113331007]]}}}}
 
    {:description "Simple laterality — normalize preserves user refinement on primitive"
     :expression  "182201002 : 272741003 = 24028007"
@@ -345,19 +344,19 @@
                                      :refinements   [[{:conceptId 272741003} {:conceptId 24028007}]]}}
     :normalized  {:cf/definition-status :subtype-of
                   :cf/focus-concepts    #{182201002}
-                  :cf/ungrouped        #{[272741003 24028007]}}}])
+                  :cf/ungrouped        #{[272741003 [:concept 24028007]]}}}])
 
 (deftest ^:live expression-tests
   (with-open [st (store/open-store "snomed.db/store.db")]
-    (doseq [{:keys [description expression parsed errors normalized live]} test-cases]
+    (doseq [{:keys [description expression parsed invalid normalized live]} test-cases]
       (testing description
-        (let [result (scg/parse expression)]
+        (let [result (scg/str->ctu expression)]
           (is (= parsed result) (str "Parse mismatch for: " expression))
           (is (s/valid? :ctu/expression result)
               (str "Spec failure for: " expression "\n"
                    (s/explain-str :ctu/expression result)))
-          (let [rendered (scg/render result)
-                reparsed (scg/parse rendered)]
+          (let [rendered (scg/ctu->str result)
+                reparsed (scg/str->ctu rendered)]
             (is (= result reparsed)
                 (str "Roundtrip mismatch for: " expression "\n  rendered: " rendered)))
           (let [canon (scg/canonicalize result)]
@@ -365,14 +364,14 @@
                 (str "Canonicalize not idempotent for: " expression))
             (is (s/valid? :ctu/expression canon)
                 (str "Canonical form fails spec for: " expression)))
-          (when live
-            (is (= errors (scg/errors st result))))
+          (when (and live invalid)
+            (is (thrown? clojure.lang.ExceptionInfo (scg/validate st result))))
           (when normalized
-            (let [norm (scg/normalize st result)]
+            (let [norm (scg/ctu->cf+normalize st result)]
               (is (= normalized norm))
               (is (s/valid? :cf/expression norm)
                   (s/explain-str :cf/expression norm))
-              (let [round-tripped (scg/normalize st (scg/classifiable->ctu norm))]
+              (let [round-tripped (scg/ctu->cf+normalize st (scg/cf->ctu norm))]
                 (is (= norm round-tripped)
                     "Normalization should be idempotent through round-trip")))))))))
 
@@ -390,14 +389,14 @@
 
 (deftest canonicalize-equivalence
   (doseq [exprs canonical-equivalences]
-    (let [canonical-forms (map (comp scg/canonicalize scg/parse) exprs)]
+    (let [canonical-forms (map (comp scg/canonicalize scg/str->ctu) exprs)]
       (is (apply = canonical-forms)
           (str "Not canonically equivalent: " (pr-str exprs))))))
 
 (deftest ^:live updating-terms
   (with-open [st (store/open-store "snomed.db/store.db")]
-    (let [parsed (scg/parse "91143003 |Albuterol| : 411116001 |Has manufactured dose form| = 385023001 |oral solution| , { 127489000 |Has active ingredient| = 372897005 |Albuterol| , 179999999100 |Has basis of strength| = 372897005 |Albuterol| , 189999999103 |Has strength value| = #0.083 , 199999999101 |Has strength numerator unit| = 118582008 |%| }")
-          updated (scg/parse (scg/render st parsed {:update-terms? true :accept-language "en-GB"}))
+    (let [parsed (scg/str->ctu "91143003 |Albuterol| : 411116001 |Has manufactured dose form| = 385023001 |oral solution| , { 127489000 |Has active ingredient| = 372897005 |Albuterol| , 179999999100 |Has basis of strength| = 372897005 |Albuterol| , 189999999103 |Has strength value| = #0.083 , 199999999101 |Has strength numerator unit| = 118582008 |%| }")
+          updated (scg/str->ctu (scg/ctu->str st parsed {:update-terms? true :accept-language "en-GB"}))
           group2 (second (get-in updated [:subExpression :refinements]))
           active-ingredient-pair (first (filter #(= 127489000 (:conceptId (first %))) group2))]
       (is (= {:conceptId 372897005 :term "Salbutamol"} (second active-ingredient-pair))
@@ -405,7 +404,7 @@
 
 
 
-(def concept->expression*-cases
+(def concept->ctu*-cases
   [{:description "Primitive concept (Clinical finding) — itself as sole focus, <<< status"
     :concept-id  404684003
     :defined?    false
@@ -441,26 +440,26 @@
                                      :refinements   [#{[{:conceptId 260686004} {:conceptId 129304002}]
                                                        [{:conceptId 405813007} {:conceptId 66754008}]}]}}}])
 
-(deftest concept->expression*
-  (doseq [{:keys [description concept-id defined? properties expected]} concept->expression*-cases]
+(deftest concept->ctu*
+  (doseq [{:keys [description concept-id defined? properties expected]} concept->ctu*-cases]
     (testing description
-      (let [expr (scg/concept->expression* concept-id defined? properties)]
+      (let [expr (scg/concept->ctu* concept-id defined? properties)]
         (is (= expected expr))
         (is (s/valid? :ctu/expression expr)
             (s/explain-str :ctu/expression expr))
         (is (= expr (scg/canonicalize expr))
             "Should already be in canonical form")
-        (let [rendered (scg/render (scg/strip-terms expr))
-              reparsed (scg/parse rendered)]
+        (let [rendered (scg/ctu->str (scg/strip-terms expr))
+              reparsed (scg/str->ctu rendered)]
           (is (= expr reparsed)
               (str "Round-trip failed. Rendered: " rendered)))))))
 
 
 
-(deftest ^:live concept->expression
+(deftest ^:live concept->ctu
   (with-open [st (store/open-store "snomed.db/store.db")]
     (testing "Primitive concept (Multiple sclerosis) — self as focus, <<< status"
-      (let [expr (scg/concept->expression st 24700007)]
+      (let [expr (scg/concept->ctu st 24700007)]
         (is (= :subtype-of (:definitionStatus expr)))
         (is (= [{:conceptId 24700007}] (get-in expr [:subExpression :focusConcepts])))
         (is (seq (get-in expr [:subExpression :refinements]))
@@ -470,7 +469,7 @@
         (is (= expr (scg/canonicalize expr))
             "Should already be in canonical form")))
     (testing "Fully-defined concept (Appendectomy) — IS-A parents as foci, === status"
-      (let [expr (scg/concept->expression st 80146002)]
+      (let [expr (scg/concept->ctu st 80146002)]
         (is (= :equivalent-to (:definitionStatus expr)))
         (is (< 1 (count (get-in expr [:subExpression :focusConcepts])))
             "Fully-defined concept should have multiple focus concepts (IS-A parents)")
@@ -481,7 +480,7 @@
         (is (= expr (scg/canonicalize expr))
             "Should already be in canonical form")))
     (testing "Concept with no non-IS-A properties (Clinical finding)"
-      (let [expr (scg/concept->expression st 404684003)]
+      (let [expr (scg/concept->ctu st 404684003)]
         (is (= :subtype-of (:definitionStatus expr)))
         (is (= [{:conceptId 404684003}] (get-in expr [:subExpression :focusConcepts])))
         (is (nil? (get-in expr [:subExpression :refinements]))
@@ -489,13 +488,13 @@
         (is (s/valid? :ctu/expression expr))))
     (testing "Round-trip through render and parse"
       (doseq [concept-id [24700007 80146002 404684003]]
-        (let [expr (scg/concept->expression st concept-id)
-              rendered (scg/render (scg/strip-terms expr))
-              reparsed (scg/parse rendered)]
+        (let [expr (scg/concept->ctu st concept-id)
+              rendered (scg/ctu->str (scg/strip-terms expr))
+              reparsed (scg/str->ctu rendered)]
           (is (= expr reparsed)
               (str "Round-trip failed for " concept-id ". Rendered: " rendered)))))
     (testing "Non-existent concept returns nil"
-      (is (nil? (scg/concept->expression st 100000102))))))
+      (is (nil? (scg/concept->ctu st 100000102))))))
 
 (def subsumption-test-cases
   "Test cases for expression subsumption.
@@ -554,18 +553,171 @@
   (with-open [st (store/open-store "snomed.db/store.db")]
     (doseq [{:keys [description exp a b]} subsumption-test-cases]
       (testing description
-        (is (= exp (scg/subsumes? st (scg/parse a) (scg/parse b))))))))
+        (is (= exp (scg/subsumes? st (scg/str->ctu a) (scg/str->ctu b))))))))
+
+(deftest ^:live subsumption-invalid-concepts
+  (with-open [st (store/open-store "snomed.db/store.db")]
+    (testing "non-existent focus concept should throw"
+      (is (thrown? clojure.lang.ExceptionInfo (scg/subsumes? st (scg/str->ctu "100000102") (scg/str->ctu "24700007")))))
+    (testing "valid concept compared to non-existent concept should throw"
+      (is (thrown? clojure.lang.ExceptionInfo (scg/subsumes? st (scg/str->ctu "24700007") (scg/str->ctu "100000102")))))
+    (testing "two non-existent concepts should throw"
+      (is (thrown? clojure.lang.ExceptionInfo (scg/subsumes? st (scg/str->ctu "100000102") (scg/str->ctu "100000102")))))
+    (testing "non-existent attribute value should throw"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (scg/subsumes? st
+                                  (scg/str->ctu "73211009 : 272741003 = 100000102")
+                                  (scg/str->ctu "73211009 : 272741003 = 7771000")))))))
 
 (deftest ^:live subsumption-symmetry
   (with-open [st (store/open-store "snomed.db/store.db")]
     (testing "mutual subsumption = equivalence"
-      (let [a (scg/parse "80146002")
-            b (scg/parse "80146002")]
+      (let [a (scg/str->ctu "80146002")
+            b (scg/str->ctu "80146002")]
         (is (and (scg/subsumes? st a b) (scg/subsumes? st b a)))))
     (testing "terms don't affect symmetry"
-      (let [a (scg/parse "80146002 |Appendectomy|")
-            b (scg/parse "80146002")]
+      (let [a (scg/str->ctu "80146002 |Appendectomy|")
+            b (scg/str->ctu "80146002")]
         (is (and (scg/subsumes? st a b) (scg/subsumes? st b a)))))))
+
+(def ctu->cf-test-cases
+  [{:description "Bare concept preserves :equivalent-to and concept ID"
+    :expression  "80146002"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{80146002}}}
+
+   {:description "Explicit subtype-of preserved"
+    :expression  "<<< 73211009 : 363698007 = 113331007"
+    :expected    {:cf/definition-status :subtype-of
+                  :cf/focus-concepts    #{73211009}
+                  :cf/ungrouped        #{[363698007 [:concept 113331007]]}}}
+
+   {:description "Ungrouped refinement"
+    :expression  "80146002 : 272741003 = 7771000"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{80146002}
+                  :cf/ungrouped        #{[272741003 [:concept 7771000]]}}}
+
+   {:description "Grouped refinement"
+    :expression  "71388002 : { 260686004 = 129304002 , 405813007 = 15497006 }"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{71388002}
+                  :cf/groups           #{#{[260686004 [:concept 129304002]]
+                                          [405813007 [:concept 15497006]]}}}}
+
+   {:description "Nested expression in attribute value"
+    :expression  "397956004 : 363704007 = ( 24136001 : 272741003 = 7771000 )"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{397956004}
+                  :cf/ungrouped        #{[363704007
+                                          [:expression {:cf/definition-status :equivalent-to
+                                                        :cf/focus-concepts    #{24136001}
+                                                        :cf/ungrouped        #{[272741003 [:concept 7771000]]}}]]}}}
+
+   {:description "Multiple focus concepts"
+    :expression  "421720008 + 7946007"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{421720008 7946007}}}
+
+   {:description "Terms are stripped — only IDs remain"
+    :expression  "80146002 |Appendectomy| : 272741003 |Laterality| = 7771000 |Left|"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{80146002}
+                  :cf/ungrouped        #{[272741003 [:concept 7771000]]}}}
+
+   {:description "Numeric integer value tagged as :numeric"
+    :expression  "774586009 : 189999999103 = #500"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{774586009}
+                  :cf/ungrouped        #{[189999999103 [:numeric 500.0]]}}}
+
+   {:description "Numeric decimal value tagged as :numeric"
+    :expression  "91143003 : 189999999103 = #0.083"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{91143003}
+                  :cf/ungrouped        #{[189999999103 [:numeric 0.083]]}}}
+
+   {:description "String value tagged as :string"
+    :expression  "91143003 : 189999999103 = \"hello\""
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{91143003}
+                  :cf/ungrouped        #{[189999999103 [:string "hello"]]}}}
+
+   {:description "Boolean true tagged as :boolean"
+    :expression  "91143003 : 189999999103 = true"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{91143003}
+                  :cf/ungrouped        #{[189999999103 [:boolean true]]}}}
+
+   {:description "Boolean false tagged as :boolean"
+    :expression  "91143003 : 189999999103 = false"
+    :expected    {:cf/definition-status :equivalent-to
+                  :cf/focus-concepts    #{91143003}
+                  :cf/ungrouped        #{[189999999103 [:boolean false]]}}}])
+
+(deftest ctu->cf
+  (doseq [{:keys [description expression expected]} ctu->cf-test-cases]
+    (testing description
+      (let [parsed (scg/str->ctu expression)
+            result (scg/ctu->cf parsed)]
+        (is (= expected result))
+        (is (s/valid? :cf/expression result)
+            (s/explain-str :cf/expression result))))))
+
+(deftest cf-to-ctu-round-trip
+  (testing "CF→CTU→CF round-trip preserves all value types"
+    (doseq [{:keys [description expected]} ctu->cf-test-cases]
+      (testing description
+        (let [round-tripped (scg/ctu->cf (scg/cf->ctu expected))]
+          (is (= expected round-tripped)
+              (str "Round-trip failed: " (pr-str expected) " → " (pr-str round-tripped))))))))
+
+(def cf-subsumes-concrete-cases
+  "Test cases for cf-subsumes? with concrete (non-concept) attribute values.
+  Uses nil as the store since all focus concepts are identical and concrete
+  values never invoke is-a? — equality checks short-circuit.
+  Uses real SNOMED concept IDs to satisfy Verhoeff spec instrumentation."
+  [{:description "identical numeric ungrouped — subsumes"
+    :exp true
+    :a {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/ungrouped #{[363698007 [:numeric 500.0]]}}
+    :b {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/ungrouped #{[363698007 [:numeric 500.0]]}}}
+   {:description "different numeric values — no subsumption"
+    :exp false
+    :a {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/ungrouped #{[363698007 [:numeric 500.0]]}}
+    :b {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/ungrouped #{[363698007 [:numeric 250.0]]}}}
+   {:description "identical string in group — subsumes"
+    :exp true
+    :a {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/groups #{#{[363698007 [:string "hello"]]}}}
+    :b {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/groups #{#{[363698007 [:string "hello"]]}}}}
+   {:description "identical boolean — subsumes"
+    :exp true
+    :a {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/ungrouped #{[363698007 [:boolean true]]}}
+    :b {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/ungrouped #{[363698007 [:boolean true]]}}}
+   {:description "mismatched value tags — no subsumption"
+    :exp false
+    :a {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/ungrouped #{[363698007 [:numeric 1]]}}
+    :b {:cf/definition-status :subtype-of :cf/focus-concepts #{73211009}
+        :cf/ungrouped #{[363698007 [:string "1"]]}}}])
+
+(deftest cf-subsumes-concrete-values
+  (doseq [{:keys [description exp a b]} cf-subsumes-concrete-cases]
+    (testing description
+      (is (= exp (scg/cf-subsumes? nil a b))))))
+
+(deftest invalid-expressions
+  (testing "Invalid SCG expressions should throw"
+    (doseq [s ["xxxx" "not a concept" "!!!" "" "abc123" ": = 1234"]]
+      (is (thrown? Exception (scg/str->ctu s))
+          (str "Expected exception for invalid expression: " (pr-str s))))))
 
 (comment
   (run-tests))

--- a/test/src/com/eldrix/hermes/scg_test.clj
+++ b/test/src/com/eldrix/hermes/scg_test.clj
@@ -365,7 +365,7 @@
             (is (s/valid? :ctu/expression canon)
                 (str "Canonical form fails spec for: " expression)))
           (when (and live invalid)
-            (is (thrown? clojure.lang.ExceptionInfo (scg/validate st result))))
+            (is (not (scg/valid? st result))))
           (when normalized
             (let [norm (scg/ctu->cf+normalize st result)]
               (is (= normalized norm))

--- a/test/src/com/eldrix/hermes/server_test.clj
+++ b/test/src/com/eldrix/hermes/server_test.clj
@@ -1,45 +1,44 @@
 (ns com.eldrix.hermes.server-test
   (:require [clojure.data.json :as json]
             [clojure.spec.test.alpha :as stest]
-            [clojure.test :refer [deftest is use-fixtures]]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [com.eldrix.hermes.cmd.server :as server]
             [com.eldrix.hermes.core :as hermes]
             [io.pedestal.connector.test :refer [response-for]]
             [io.pedestal.http.route :as route]))
 
-(def url-for
-  (route/url-for-routes (route/expand-routes server/routes)))
-
 (def ^:dynamic *svc* nil)
 (def ^:dynamic *connector* nil)
+(def ^:dynamic *url-for* nil)
 
 (defn live-test-fixture [f]
   (let [svc (hermes/open "snomed.db")]
-    (binding [*svc* svc  ;; bindings are performed in parallel, unlike `let`
-              *connector* (server/create-connector svc {})]
+    (binding [*svc* svc
+              *connector* (server/create-connector svc {})
+              *url-for* (route/url-for-routes (route/expand-routes (server/routes svc)))]
       (stest/with-instrument-disabled (f))  ;; turn off instrumentation, as we will be using erroneous input
       (hermes/close *svc*))))
 
 (use-fixtures :once live-test-fixture)
 
 (deftest ^:live get-concept
-  (is (= 200 (:status (response-for *connector* :get (url-for ::server/get-concept :path-params {:concept-id "24700007"})))))
+  (is (= 200 (:status (response-for *connector* :get (*url-for* ::server/get-concept :path-params {:concept-id "24700007"})))))
   (is (= 200 (:status (response-for *connector*
-                                    :get (url-for ::server/get-concept :path-params {:concept-id "80146002"})
+                                    :get (*url-for* ::server/get-concept :path-params {:concept-id "80146002"})
                                     :headers {"accept" "application/edn"}))))
-  (is (= 404 (:status (response-for *connector* :get (url-for ::server/get-concept :path-params {:concept-id "123"})))))
-  (is (= 404 (:status (response-for *connector* :get (url-for ::server/get-concept :path-params {:concept-id "abc"}))))))
+  (is (= 404 (:status (response-for *connector* :get (*url-for* ::server/get-concept :path-params {:concept-id "123"})))))
+  (is (= 404 (:status (response-for *connector* :get (*url-for* ::server/get-concept :path-params {:concept-id "abc"}))))))
 
 (deftest ^:live get-concept-descriptions
-  (is (= 200 (:status (response-for *connector* :get (url-for ::server/get-concept-descriptions :path-params {:concept-id "24700007"})))))
-  (is (= 404 (:status (response-for *connector* :get (url-for ::server/get-concept-descriptions :path-params {:concept-id "123"}))))))
+  (is (= 200 (:status (response-for *connector* :get (*url-for* ::server/get-concept-descriptions :path-params {:concept-id "24700007"})))))
+  (is (= 404 (:status (response-for *connector* :get (*url-for* ::server/get-concept-descriptions :path-params {:concept-id "123"}))))))
 
 (deftest ^:live get-preferred
   (let [en-GB (response-for *connector*
-                            :get (url-for ::server/get-concept-preferred-description :path-params {:concept-id "80146002"})
+                            :get (*url-for* ::server/get-concept-preferred-description :path-params {:concept-id "80146002"})
                             :headers {"accept-language" "en-GB"})
         en-US (response-for *connector*
-                            :get (url-for ::server/get-concept-preferred-description :path-params {:concept-id "80146002"})
+                            :get (*url-for* ::server/get-concept-preferred-description :path-params {:concept-id "80146002"})
                             :headers {"accept-language" "en-US"})]
     (is (= 200 (:status en-GB)))
     (is (= 200 (:status en-US)))
@@ -47,15 +46,34 @@
     (is (= "Appendectomy" (get (json/read-str (:body en-US)) "term")))))
 
 (deftest ^:live get-extended-concept
-  (is (= 200 (:status (response-for *connector* :get (url-for ::server/get-extended-concept :path-params {:concept-id "24700007"})))))
-  (is (= 404 (:status (response-for *connector* :get (url-for ::server/get-extended-concept :path-params {:concept-id "123"}))))))
+  (is (= 200 (:status (response-for *connector* :get (*url-for* ::server/get-extended-concept :path-params {:concept-id "24700007"})))))
+  (is (= 404 (:status (response-for *connector* :get (*url-for* ::server/get-extended-concept :path-params {:concept-id "123"}))))))
 
 (deftest ^:live get-properties
-  (is (= 200 (:status (response-for *connector* :get (url-for ::server/get-concept-properties :path-params {:concept-id "24700007"})))))
-  (is (= 404 (:status (response-for *connector* :get (url-for ::server/get-concept-properties :path-params {:concept-id "123"}))))))
+  (is (= 200 (:status (response-for *connector* :get (*url-for* ::server/get-concept-properties :path-params {:concept-id "24700007"})))))
+  (is (= 404 (:status (response-for *connector* :get (*url-for* ::server/get-concept-properties :path-params {:concept-id "123"}))))))
+
+(deftest ^:live expression-subsumes
+  (let [subsumes-url (*url-for* ::server/expression-subsumes)]
+    (testing "valid subsumption — parent subsumes child"
+      (let [resp (response-for *connector* :get (str subsumes-url "?a=6118003&b=24700007"))]
+        (is (= 200 (:status resp)))
+        (is (= "subsumes" (get (json/read-str (:body resp)) "outcome")))))
+    (testing "valid subsumption — concept subsumes itself"
+      (let [resp (response-for *connector* :get (str subsumes-url "?a=24700007&b=24700007"))]
+        (is (= 200 (:status resp)))
+        (is (= "equivalent" (get (json/read-str (:body resp)) "outcome")))))
+    (testing "missing parameter a"
+      (is (= 400 (:status (response-for *connector* :get (str subsumes-url "?b=24700007"))))))
+    (testing "missing parameter b"
+      (is (= 400 (:status (response-for *connector* :get (str subsumes-url "?a=24700007"))))))
+    (testing "non-existent concept returns 400"
+      (is (= 400 (:status (response-for *connector* :get (str subsumes-url "?a=24700007&b=100000102"))))))
+    (testing "invalid concept ID (bad check digit) returns 400"
+      (is (= 400 (:status (response-for *connector* :get (str subsumes-url "?a=24700007&b=24700001"))))))))
 
 (comment
   (def *svc* (hermes/open "snomed.db"))
   (def *connector* (server/create-connector *svc* {}))
-  (response-for *connector* :get (url-for ::server/get-concept :path-params {:concept-id "24700007"}))
-  (:status (response-for *connector* :get (url-for ::server/get-concept :path-params {:concept-id 24700007}))))
+  (response-for *connector* :get (*url-for* ::server/get-concept :path-params {:concept-id "24700007"}))
+  (:status (response-for *connector* :get (*url-for* ::server/get-concept :path-params {:concept-id 24700007}))))


### PR DESCRIPTION
## Summary

- **OWL reasoning**: Add OWL API + ELK reasoner integration for expression classification, subsumption checking (structural and OWL modes), and necessary normal form (NNF) computation
- **SCG enhancements**: Close-to-user/close-to-formal representations, spec-based validation (`valid?` predicate), structural subsumption, expression normalization, and `replace-historical` for opt-in inactive concept replacement
- **Public API**: `subsumes` (FHIR-aligned, multi-dispatch: concept IDs, SCG strings, CTU expressions), `classify-expression`, `necessary-normal-form` with options maps; fast IS-A path for simple concept pairs
- **Infrastructure**: OWL expression/axiom reference set import, CLI/server support for OWL import and reasoning status, ELK reasoner lifecycle management
- **Testing**: Pure OWL unit tests (axiom round-tripping, NNF, ECL generation), oracle cross-checks of structural subsumption against OWL reasoner, generative spec-based tests, 60+ hand-written subsumption cases

## Changes across 24 files (+2930 / -305)

| Area | Key files |
|------|-----------|
| OWL reasoning | `impl/owl.clj` (730 lines new), `impl/reasoner.clj` (62 lines new) |
| SCG grammar | `impl/scg.clj` (refactored +431/-105) |
| Public API | `core.clj` (+172), `snomed.clj` (+7) |
| Import | `importer.clj` (+68) |
| CLI/Server | `cmd/cli.clj`, `cmd/server.clj`, `cmd/core.clj` |
| Tests | `owl_test.clj`, `owl_oracle_test.clj`, `owl_full_test.clj`, `scg_test.clj` |
| Docs | `README.md` (+141) |

## Test plan

- [ ] `clojure -M:test -e :live` — unit tests pass (runs in CI on every PR)
- [ ] `clojure -M:test` — full test suite including OWL oracle tests (requires SNOMED DB)
- [ ] Verify OWL reasoning endpoints via server (`/subsumes`, `/classify`, `/nnf`)
- [ ] Confirm backwards compatibility of existing SCG/core API

🤖 Generated with [Claude Code](https://claude.com/claude-code)